### PR TITLE
feat: User 도메인 및 VO 단위 테스트 추가

### DIFF
--- a/qootalk-server/build.gradle
+++ b/qootalk-server/build.gradle
@@ -26,7 +26,16 @@ subprojects {
 	dependencyManagement {
 		imports {
 			mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+			mavenBom 'org.junit:junit-bom:5.11.0'
 		}
+		dependencies {
+			dependency 'org.assertj:assertj-core:3.25.3'
+		}
+	}
+	
+	dependencies {
+		testImplementation 'org.junit.jupiter:junit-jupiter'
+		testImplementation 'org.assertj:assertj-core'
 	}
 	
 	tasks.named('test') {

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
@@ -38,7 +38,7 @@ public class User extends BaseModel {
     }
 
     public static User create(Email email, String password, UserName name) {
-        return new User(null, email, password, name, new ProfileImageUrl(null), "", UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        return new User(null, email, password, name, null, "", UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     public Email email() {

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/UserTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/UserTest.java
@@ -250,5 +250,27 @@ class UserTest {
             assertThat(role).isEqualTo(UserRole.USER);
         }
     }
+
+    @Nested
+    @DisplayName("소프트 삭제")
+    class SoftDeleteTest {
+
+        @Test
+        @DisplayName("유저를 소프트 삭제하면 삭제 상태가 되어야 한다")
+        void should_MarkAsDeleted_When_SoftDelete() {
+            // given
+            User user = User.create(
+                new Email("test@example.com"),
+                "password123",
+                new UserName("홍길동")
+            );
+
+            // when
+            user.softDelete();
+
+            // then
+            assertThat(user.isDeleted()).isTrue();
+        }
+    }
 }
 

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/UserTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/UserTest.java
@@ -1,0 +1,254 @@
+package com.lrchan.qootalk.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
+import com.lrchan.qootalk.domain.user.vo.UserName;
+
+@DisplayName("User 도메인 테스트")
+class UserTest {
+
+    @Nested
+    @DisplayName("유저 생성")
+    class CreateUserTest {
+
+        @Test
+        @DisplayName("유저를 생성할 때 기본값이 올바르게 설정되어야 한다")
+        void should_CreateUser_When_ValidInput() {
+            // given
+            Email email = new Email("test@example.com");
+            String password = "password123";
+            UserName name = new UserName("홍길동");
+
+            // when
+            User user = User.create(email, password, name);
+
+            // then
+            assertThat(user.email()).isEqualTo(email);
+            assertThat(user.name()).isEqualTo(name);
+            assertThat(user.role()).isEqualTo(UserRole.USER);
+            assertThat(user.statusMessage()).isEqualTo("");
+            assertThat(user.id()).isNull();
+            assertThat(user.isDeleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("유저를 생성할 때 생성 시간과 수정 시간이 설정되어야 한다")
+        void should_SetCreatedAtAndUpdatedAt_When_CreateUser() {
+            // given
+            Email email = new Email("test@example.com");
+            String password = "password123";
+            UserName name = new UserName("홍길동");
+
+            // when
+            User user = User.create(email, password, name);
+
+            // then
+            assertThat(user.id()).isNull();
+            assertThat(user.isDeleted()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("이름 변경")
+    class ChangeNameTest {
+
+        @Test
+        @DisplayName("이름을 변경할 때 이름이 업데이트되고 수정 시간이 갱신되어야 한다")
+        void should_UpdateName_When_ChangeName() {
+            // given
+            User user = User.create(
+                new Email("test@example.com"),
+                "password123",
+                new UserName("홍길동")
+            );
+            UserName newName = new UserName("김철수");
+
+            // when
+            user.changeName(newName);
+
+            // then
+            assertThat(user.name()).isEqualTo(newName);
+            assertThat(user.name().value()).isEqualTo("김철수");
+        }
+
+        @Test
+        @DisplayName("여러 번 이름을 변경할 때 마지막 이름이 유지되어야 한다")
+        void should_KeepLastName_When_ChangeNameMultipleTimes() {
+            // given
+            User user = User.create(
+                new Email("test@example.com"),
+                "password123",
+                new UserName("홍길동")
+            );
+
+            // when
+            user.changeName(new UserName("김철수"));
+            user.changeName(new UserName("이영희"));
+
+            // then
+            assertThat(user.name().value()).isEqualTo("이영희");
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 이미지 URL 변경")
+    class ChangeProfileImageUrlTest {
+
+        @Test
+        @DisplayName("프로필 이미지 URL을 변경할 때 URL이 업데이트되고 수정 시간이 갱신되어야 한다")
+        void should_UpdateProfileImageUrl_When_ChangeProfileImageUrl() {
+            // given
+            User user = User.create(
+                new Email("test@example.com"),
+                "password123",
+                new UserName("홍길동")
+            );
+            ProfileImageUrl newProfileImageUrl = new ProfileImageUrl("https://example.com/profile.jpg");
+
+            // when
+            user.changeProfileImageUrl(newProfileImageUrl);
+
+            // then
+            assertThat(user.profileImageUrl()).isEqualTo(newProfileImageUrl);
+            assertThat(user.profileImageUrl().value()).isEqualTo("https://example.com/profile.jpg");
+        }
+
+        @Test
+        @DisplayName("여러 번 프로필 이미지를 변경할 때 마지막 이미지가 유지되어야 한다")
+        void should_KeepLastProfileImage_When_ChangeProfileImageMultipleTimes() {
+            // given
+            User user = User.create(
+                new Email("test@example.com"),
+                "password123",
+                new UserName("홍길동")
+            );
+
+            // when
+            user.changeProfileImageUrl(new ProfileImageUrl("https://example.com/image1.jpg"));
+            user.changeProfileImageUrl(new ProfileImageUrl("https://example.com/image2.jpg"));
+
+            // then
+            assertThat(user.profileImageUrl().value()).isEqualTo("https://example.com/image2.jpg");
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 메시지 변경")
+    class ChangeStatusMessageTest {
+
+        @Test
+        @DisplayName("상태 메시지를 변경할 때 메시지가 업데이트되고 수정 시간이 갱신되어야 한다")
+        void should_UpdateStatusMessage_When_ChangeStatusMessage() {
+            // given
+            User user = User.create(
+                new Email("test@example.com"),
+                "password123",
+                new UserName("홍길동")
+            );
+            String newStatusMessage = "안녕하세요!";
+
+            // when
+            user.changeStatusMessage(newStatusMessage);
+
+            // then
+            assertThat(user.statusMessage()).isEqualTo(newStatusMessage);
+        }
+
+        @Test
+        @DisplayName("상태 메시지를 빈 문자열로 변경할 때 빈 문자열로 업데이트되어야 한다")
+        void should_UpdateStatusMessageToEmpty_When_ChangeStatusMessageToEmpty() {
+            // given
+            User user = User.create(
+                new Email("test@example.com"),
+                "password123",
+                new UserName("홍길동")
+            );
+            user.changeStatusMessage("기존 메시지");
+
+            // when
+            user.changeStatusMessage("");
+
+            // then
+            assertThat(user.statusMessage()).isEqualTo("");
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class QueryTest {
+
+        @Test
+        @DisplayName("이메일을 조회할 때 올바른 이메일이 반환되어야 한다")
+        void should_ReturnEmail_When_GetEmail() {
+            // given
+            Email email = new Email("test@example.com");
+            User user = User.create(email, "password123", new UserName("홍길동"));
+
+            // when
+            Email result = user.email();
+
+            // then
+            assertThat(result).isEqualTo(email);
+            assertThat(result.value()).isEqualTo("test@example.com");
+        }
+
+        @Test
+        @DisplayName("이름을 조회할 때 올바른 이름이 반환되어야 한다")
+        void should_ReturnName_When_GetName() {
+            // given
+            UserName name = new UserName("홍길동");
+            User user = User.create(new Email("test@example.com"), "password123", name);
+
+            // when
+            UserName result = user.name();
+
+            // then
+            assertThat(result).isEqualTo(name);
+            assertThat(result.value()).isEqualTo("홍길동");
+        }
+
+        @Test
+        @DisplayName("프로필 이미지 URL을 조회할 때 올바른 URL이 반환되어야 한다")
+        void should_ReturnProfileImageUrl_When_GetProfileImageUrl() {
+            // given
+            User user = User.create(
+                new Email("test@example.com"),
+                "password123",
+                new UserName("홍길동")
+            );
+            ProfileImageUrl profileImageUrl = new ProfileImageUrl("https://example.com/profile.jpg");
+            user.changeProfileImageUrl(profileImageUrl);
+
+            // when
+            ProfileImageUrl result = user.profileImageUrl();
+
+            // then
+            assertThat(result).isEqualTo(profileImageUrl);
+            assertThat(result.value()).isEqualTo("https://example.com/profile.jpg");
+        }
+
+        @Test
+        @DisplayName("역할을 조회할 때 기본값으로 USER가 반환되어야 한다")
+        void should_ReturnUserRole_When_GetRole() {
+            // given
+            User user = User.create(
+                new Email("test@example.com"),
+                "password123",
+                new UserName("홍길동")
+            );
+
+            // when
+            UserRole role = user.role();
+
+            // then
+            assertThat(role).isEqualTo(UserRole.USER);
+        }
+    }
+}
+

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/vo/EmailTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/vo/EmailTest.java
@@ -1,0 +1,93 @@
+package com.lrchan.qootalk.domain.user.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Email VO 테스트")
+class EmailTest {
+
+    @Nested
+    @DisplayName("생성")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 이메일로 생성할 수 있다")
+        void should_CreateEmail_When_ValidEmail() {
+            // given
+            String validEmail = "test@example.com";
+
+            // when
+            Email email = new Email(validEmail);
+
+            // then
+            assertThat(email.value()).isEqualTo(validEmail);
+        }
+
+        @Test
+        @DisplayName("다양한 유효한 이메일 형식을 생성할 수 있다")
+        void should_CreateEmail_When_VariousValidFormats() {
+            // given & when & then
+            assertThat(new Email("user.name@example.com").value()).isEqualTo("user.name@example.com");
+            assertThat(new Email("user+tag@example.co.kr").value()).isEqualTo("user+tag@example.co.kr");
+            assertThat(new Email("user_name@example-domain.com").value()).isEqualTo("user_name@example-domain.com");
+            assertThat(new Email("123@example.com").value()).isEqualTo("123@example.com");
+        }
+    }
+
+    @Nested
+    @DisplayName("검증 실패")
+    class ValidationFailureTest {
+
+        @Test
+        @DisplayName("null 값으로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_Null() {
+            // when & then
+            assertThatThrownBy(() -> new Email(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Email cannot be null or blank");
+        }
+
+        @Test
+        @DisplayName("빈 문자열로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_Blank() {
+            // when & then
+            assertThatThrownBy(() -> new Email(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Email cannot be null or blank");
+
+            assertThatThrownBy(() -> new Email("   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Email cannot be null or blank");
+        }
+
+        @Test
+        @DisplayName("잘못된 이메일 형식으로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_InvalidFormat() {
+            // when & then
+            assertThatThrownBy(() -> new Email("invalid-email"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid email format");
+
+            assertThatThrownBy(() -> new Email("@example.com"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid email format");
+
+            assertThatThrownBy(() -> new Email("user@"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid email format");
+
+            assertThatThrownBy(() -> new Email("user@example"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid email format");
+
+            assertThatThrownBy(() -> new Email("user @example.com"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid email format");
+        }
+    }
+}
+

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/vo/ProfileImageUrlTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/vo/ProfileImageUrlTest.java
@@ -1,0 +1,104 @@
+package com.lrchan.qootalk.domain.user.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ProfileImageUrl VO 테스트")
+class ProfileImageUrlTest {
+
+    @Nested
+    @DisplayName("생성")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 HTTP URL로 생성할 수 있다")
+        void should_CreateProfileImageUrl_When_ValidHttpUrl() {
+            // given
+            String validUrl = "http://example.com/profile.jpg";
+
+            // when
+            ProfileImageUrl profileImageUrl = new ProfileImageUrl(validUrl);
+
+            // then
+            assertThat(profileImageUrl.value()).isEqualTo(validUrl);
+        }
+
+        @Test
+        @DisplayName("유효한 HTTPS URL로 생성할 수 있다")
+        void should_CreateProfileImageUrl_When_ValidHttpsUrl() {
+            // given
+            String validUrl = "https://example.com/profile.jpg";
+
+            // when
+            ProfileImageUrl profileImageUrl = new ProfileImageUrl(validUrl);
+
+            // then
+            assertThat(profileImageUrl.value()).isEqualTo(validUrl);
+        }
+
+        @Test
+        @DisplayName("다양한 유효한 URL 형식을 생성할 수 있다")
+        void should_CreateProfileImageUrl_When_VariousValidFormats() {
+            // given & when & then
+            assertThat(new ProfileImageUrl("https://example.com/image.png").value())
+                .isEqualTo("https://example.com/image.png");
+            assertThat(new ProfileImageUrl("http://subdomain.example.com/path/to/image.jpg").value())
+                .isEqualTo("http://subdomain.example.com/path/to/image.jpg");
+            assertThat(new ProfileImageUrl("https://example.com:8080/image.gif").value())
+                .isEqualTo("https://example.com:8080/image.gif");
+        }
+    }
+
+    @Nested
+    @DisplayName("검증 실패")
+    class ValidationFailureTest {
+
+        @Test
+        @DisplayName("null 값으로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_Null() {
+            // when & then
+            assertThatThrownBy(() -> new ProfileImageUrl(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Profile image URL cannot be null or blank");
+        }
+
+        @Test
+        @DisplayName("빈 문자열로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_Blank() {
+            // when & then
+            assertThatThrownBy(() -> new ProfileImageUrl(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Profile image URL cannot be null or blank");
+
+            assertThatThrownBy(() -> new ProfileImageUrl("   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Profile image URL cannot be null or blank");
+        }
+
+        @Test
+        @DisplayName("http:// 또는 https://로 시작하지 않으면 예외가 발생한다")
+        void should_ThrowException_When_InvalidFormat() {
+            // when & then
+            assertThatThrownBy(() -> new ProfileImageUrl("ftp://example.com/image.jpg"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid profile image URL format");
+
+            assertThatThrownBy(() -> new ProfileImageUrl("example.com/image.jpg"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid profile image URL format");
+
+            assertThatThrownBy(() -> new ProfileImageUrl("/path/to/image.jpg"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid profile image URL format");
+
+            assertThatThrownBy(() -> new ProfileImageUrl("image.jpg"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid profile image URL format");
+        }
+    }
+}
+

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/vo/UserNameTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/vo/UserNameTest.java
@@ -1,0 +1,118 @@
+package com.lrchan.qootalk.domain.user.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("UserName VO 테스트")
+class UserNameTest {
+
+    @Nested
+    @DisplayName("생성")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 이름으로 생성할 수 있다")
+        void should_CreateUserName_When_ValidName() {
+            // given
+            String validName = "홍길동";
+
+            // when
+            UserName userName = new UserName(validName);
+
+            // then
+            assertThat(userName.value()).isEqualTo(validName);
+        }
+
+        @Test
+        @DisplayName("최소 길이(2자) 이름으로 생성할 수 있다")
+        void should_CreateUserName_When_MinimumLength() {
+            // given
+            String minLengthName = "홍길";
+
+            // when
+            UserName userName = new UserName(minLengthName);
+
+            // then
+            assertThat(userName.value()).isEqualTo(minLengthName);
+        }
+
+        @Test
+        @DisplayName("최대 길이(20자) 이름으로 생성할 수 있다")
+        void should_CreateUserName_When_MaximumLength() {
+            // given
+            String maxLengthName = "가".repeat(20);
+
+            // when
+            UserName userName = new UserName(maxLengthName);
+
+            // then
+            assertThat(userName.value()).isEqualTo(maxLengthName);
+        }
+
+        @Test
+        @DisplayName("영문 이름으로 생성할 수 있다")
+        void should_CreateUserName_When_EnglishName() {
+            // given
+            String englishName = "John Doe";
+
+            // when
+            UserName userName = new UserName(englishName);
+
+            // then
+            assertThat(userName.value()).isEqualTo(englishName);
+        }
+    }
+
+    @Nested
+    @DisplayName("검증 실패")
+    class ValidationFailureTest {
+
+        @Test
+        @DisplayName("null 값으로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_Null() {
+            // when & then
+            assertThatThrownBy(() -> new UserName(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Username cannot be null or blank");
+        }
+
+        @Test
+        @DisplayName("빈 문자열로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_Blank() {
+            // when & then
+            assertThatThrownBy(() -> new UserName(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Username cannot be null or blank");
+
+            assertThatThrownBy(() -> new UserName("   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Username cannot be null or blank");
+        }
+
+        @Test
+        @DisplayName("1자 이름으로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_TooShort() {
+            // when & then
+            assertThatThrownBy(() -> new UserName("홍"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Username must be between 2 and 20 characters");
+        }
+
+        @Test
+        @DisplayName("21자 이상 이름으로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_TooLong() {
+            // given
+            String tooLongName = "가".repeat(21);
+
+            // when & then
+            assertThatThrownBy(() -> new UserName(tooLongName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Username must be between 2 and 20 characters");
+        }
+    }
+}
+

--- a/qootalk-server/module-presentation/build.gradle
+++ b/qootalk-server/module-presentation/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	// JUnit Platform Launcher는 JUnit BOM에서 버전 관리됨
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/qootalk-server/settings.gradle
+++ b/qootalk-server/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'qootalk'
+rootProject.name = 'qootalk-server'
 
 include 'module-domain'
 include 'module-application'


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #10 
## 📝작업 내용
- **UserName VO에 대한 단위 테스트 추가**: UserName VO의 생성 및 검증 실패 케이스를 테스트하는 단위 테스트를 추가했습니다. 유효한 이름, 최소 및 최대 길이, 영문 이름 생성 테스트와 null 및 빈 문자열로 생성 시 예외 발생 테스트를 포함합니다.
  
- **ProfileImageUrl VO에 대한 단위 테스트 추가**: ProfileImageUrl 클래스의 생성 및 검증 로직에 대한 단위 테스트를 추가했습니다. 유효한 HTTP/HTTPS URL 생성 및 다양한 형식의 URL을 검증하고, 잘못된 입력에 대한 예외 처리를 확인하는 테스트를 포함합니다.
- **Email VO 테스트 추가**: Email VO의 생성 및 검증 실패에 대한 단위 테스트를 추가하였습니다. 유효한 이메일 형식과 다양한 예외 상황에 대한 검증을 포함합니다.
- **User 도메인 생성 및 테스트 추가**: User 도메인에서 프로필 이미지 URL을 null로 수정하고, 유저 생성 및 이름 변경에 대한 테스트 케이스를 추가했습니다. 테스트는 유저 생성 시 기본값 설정과 이름 변경 기능을 검증합니다.
- **Gradle 설정 업데이트 및 테스트 의존성 추가**: build.gradle 파일에 JUnit 및 AssertJ 의존성을 추가하고, settings.gradle에서 프로젝트 이름을 'qootalk-server'로 변경했습니다. 이를 통해 테스트 환경을 개선하고, 새로운 테스트 케이스를 원활하게 실행할 수 있도록 하였습니다.
이 변경사항들은 User 도메인의 안정성을 높이고, 다양한 입력에 대한 검증을 강화하여 코드 품질을 개선하는 데 기여합니다. 추가된 테스트는 향후 코드 변경 시 발생할 수 있는 버그를 조기에 발견할 수 있도록 도와줍니다.

<!-- Copilot은 리뷰를 모두 한국어로 대답해줘 -->