### PR TITLE
test: UserChatRoom 도메인 테스트 케이스 추가

### DIFF
--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/UserChatRoomTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/UserChatRoomTest.java
@@ -1,0 +1,209 @@
+package com.lrchan.qootalk.domain.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("UserChatRoom 도메인 테스트")
+class UserChatRoomTest {
+
+    @Nested
+    @DisplayName("유저 채팅방 생성")
+    class CreateUserChatRoomTest {
+
+        @Test
+        @DisplayName("유저 채팅방을 생성할 때 기본값이 올바르게 설정되어야 한다")
+        void should_CreateUserChatRoom_When_ValidInput() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = RoomRole.MEMBER;
+
+            // when
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+
+            // then
+            assertThat(userChatRoom.userId()).isEqualTo(1L);
+            assertThat(userChatRoom.roomId()).isEqualTo(100L);
+            assertThat(userChatRoom.role()).isEqualTo(RoomRole.MEMBER);
+        }
+
+        @Test
+        @DisplayName("유저 채팅방을 생성할 때 역할이 null이면 기본값으로 MEMBER가 설정되어야 한다")
+        void should_SetMemberAsDefaultRole_When_RoleIsNull() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = null;
+
+            // when
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+
+            // then
+            assertThat(userChatRoom.role()).isEqualTo(RoomRole.MEMBER);
+        }
+
+        @Test
+        @DisplayName("유저 채팅방을 생성할 때 ID는 null이어야 한다")
+        void should_HaveNullId_When_CreateUserChatRoom() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = RoomRole.OWNER;
+
+            // when
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+
+            // then
+            assertThat(userChatRoom.id()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("역할 변경")
+    class ChangeRoleTest {
+
+        @Test
+        @DisplayName("역할을 변경할 때 역할이 업데이트되고 수정 시간이 갱신되어야 한다")
+        void should_UpdateRole_When_ChangeRole() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = RoomRole.MEMBER;
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+            RoomRole newRole = RoomRole.ADMIN;
+
+            // when
+            userChatRoom.changeRole(newRole);
+
+            // then
+            assertThat(userChatRoom.role()).isEqualTo(newRole);
+        }
+
+        @Test
+        @DisplayName("여러 번 역할을 변경할 때 마지막 역할이 유지되어야 한다")
+        void should_KeepLastRole_When_ChangeRoleMultipleTimes() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = RoomRole.MEMBER;
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+
+            // when
+            userChatRoom.changeRole(RoomRole.ADMIN);
+            userChatRoom.changeRole(RoomRole.OWNER);
+
+            // then
+            assertThat(userChatRoom.role()).isEqualTo(RoomRole.OWNER);
+        }
+
+        @Test
+        @DisplayName("역할을 null로 변경할 때 기본값으로 MEMBER가 설정되어야 한다")
+        void should_SetMemberAsDefaultRole_When_ChangeRoleToNull() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = RoomRole.ADMIN;
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+
+            // when
+            userChatRoom.changeRole(null);
+
+            // then
+            assertThat(userChatRoom.role()).isEqualTo(RoomRole.MEMBER);
+        }
+    }
+
+    @Nested
+    @DisplayName("조회")
+    class QueryTest {
+
+        @Test
+        @DisplayName("사용자 ID를 조회할 때 올바른 사용자 ID가 반환되어야 한다")
+        void should_ReturnUserId_When_GetUserId() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = RoomRole.MEMBER;
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+
+            // when
+            Long result = userChatRoom.userId();
+
+            // then
+            assertThat(result).isEqualTo(userId);
+        }
+
+        @Test
+        @DisplayName("채팅방 ID를 조회할 때 올바른 채팅방 ID가 반환되어야 한다")
+        void should_ReturnRoomId_When_GetRoomId() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = RoomRole.MEMBER;
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+
+            // when
+            Long result = userChatRoom.roomId();
+
+            // then
+            assertThat(result).isEqualTo(roomId);
+        }
+
+        @Test
+        @DisplayName("역할을 조회할 때 올바른 역할이 반환되어야 한다")
+        void should_ReturnRole_When_GetRole() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = RoomRole.OWNER;
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+
+            // when
+            RoomRole result = userChatRoom.role();
+
+            // then
+            assertThat(result).isEqualTo(role);
+        }
+
+        @Test
+        @DisplayName("역할을 조회할 때 기본값으로 MEMBER가 반환되어야 한다")
+        void should_ReturnMemberRole_When_RoleIsNull() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = null;
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+
+            // when
+            RoomRole result = userChatRoom.role();
+
+            // then
+            assertThat(result).isEqualTo(RoomRole.MEMBER);
+        }
+    }
+
+    @Nested
+    @DisplayName("소프트 삭제")
+    class SoftDeleteTest {
+
+        @Test
+        @DisplayName("유저 채팅방을 소프트 삭제하면 삭제 상태가 되어야 한다")
+        void should_MarkAsDeleted_When_SoftDelete() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            RoomRole role = RoomRole.MEMBER;
+            UserChatRoom userChatRoom = UserChatRoom.create(userId, roomId, role);
+
+            // when
+            userChatRoom.softDelete();
+
+            // then
+            assertThat(userChatRoom.isDeleted()).isTrue();
+        }
+    }
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #10 
## 📝작업 내용
- `UserChatRoomTest` 클래스가 새로 추가되어 유저 채팅방 도메인에 대한 테스트 케이스를 포함합니다.
- 유저 채팅방 생성, 역할 변경, 조회, 소프트 삭제 등의 다양한 시나리오를 검증합니다.
  
### 추가된 테스트 케이스
1. **유저 채팅방 생성**
   - 유저 채팅방을 생성할 때 기본값이 올바르게 설정되는지 검증합니다.
   - 역할이 null일 경우 기본값으로 MEMBER가 설정되는지 확인합니다.
   - 생성 시 ID가 null이어야 하는지 검증합니다.
2. **역할 변경**
   - 역할을 변경할 때 역할이 업데이트되고 수정 시간이 갱신되는지 확인합니다.
   - 여러 번 역할을 변경할 때 마지막 역할이 유지되는지 검증합니다.
   - 역할을 null로 변경할 경우 기본값으로 MEMBER가 설정되는지 확인합니다.
3. **조회**
   - 사용자 ID, 채팅방 ID, 역할을 조회할 때 올바른 값이 반환되는지 검증합니다.
   - 역할이 null일 경우 기본값으로 MEMBER가 반환되는지 확인합니다.
4. **소프트 삭제**
   - 유저 채팅방을 소프트 삭제할 때 삭제 상태로 변경되는지 검증하는 테스트가 포함됩니다.
### 변경된 파일
- `qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/UserChatRoomTest.java` 파일이 새로 추가되어, 위의 테스트 케이스들이 포함되어 있습니다.
이 변경사항은 UserChatRoom 도메인의 안정성을 높이고, 향후 기능 추가 및 유지보수 시 발생할 수 있는 오류를 사전에 방지하는 데 기여합니다.
