### PR TITLE
feat: infrastructrue에 User 레포지토리 매퍼 및 엔티티 추가

### DIFF
--- a/qootalk-server/module-infrastructure/build.gradle
+++ b/qootalk-server/module-infrastructure/build.gradle
@@ -6,5 +6,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.postgresql:postgresql'
+	implementation 'jakarta.persistence:jakarta.persistence-api'
+
+	implementation 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 }
 

--- a/qootalk-server/module-infrastructure/build.gradle
+++ b/qootalk-server/module-infrastructure/build.gradle
@@ -4,5 +4,7 @@ dependencies {
 	implementation project(':module-common')
 	
 	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.postgresql:postgresql'
 }
 

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/common/BaseEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/common/BaseEntity.java
@@ -1,0 +1,42 @@
+package com.lrchan.qootalk.infrastructure.persistence.common;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+@MappedSuperclass
+public abstract class BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+        this.deletedAt = null;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long id() {
+        return id;
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/common/BaseEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/common/BaseEntity.java
@@ -9,7 +9,7 @@ public abstract class BaseEntity {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    protected Long id;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -34,6 +34,18 @@ public abstract class BaseEntity {
 
     public Long id() {
         return id;
+    }
+
+    public LocalDateTime createdAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime updatedAt() {
+        return updatedAt;
+    }
+
+    public LocalDateTime deletedAt() {
+        return deletedAt;
     }
 
     public boolean isDeleted() {

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntity.java
@@ -41,6 +41,19 @@ public class UserEntity extends BaseEntity {
         this.password = password;
         this.name = name;
         this.role = role;
+        this.profileImageUrl = null;
+        this.statusMessage = null;
+    }
+
+    public UserEntity(Long id, String email, String password, String name,
+                      String profileImageUrl, String statusMessage, UserRole role) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+        this.statusMessage = statusMessage;
+        this.role = role;
     }
 
     public String email() {

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntity.java
@@ -1,0 +1,69 @@
+package com.lrchan.qootalk.infrastructure.persistence.user;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import com.lrchan.qootalk.domain.user.UserRole;
+import com.lrchan.qootalk.infrastructure.persistence.common.BaseEntity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+@SQLDelete(sql = "UPDATE users SET deleted_at = now() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class UserEntity extends BaseEntity {
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Column(name = "status_message")
+    private String statusMessage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private UserRole role;
+
+    protected UserEntity() {
+    }
+
+    public UserEntity(String email, String password, String name, UserRole role) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.role = role;
+    }
+
+    public String email() {
+        return email;
+    }
+
+    public String password() {
+        return password;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String profileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public String statusMessage() {
+        return statusMessage;
+    }
+
+    public UserRole role() {
+        return role;
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
@@ -1,5 +1,8 @@
 package com.lrchan.qootalk.infrastructure.persistence.user;
 
+import com.lrchan.qootalk.domain.user.User;
+
+
 public class UserEntityMapper {
     
     public static User toDomain(UserEntity userEntity) {
@@ -7,6 +10,6 @@ public class UserEntityMapper {
     }
 
     public static UserEntity toEntity(User user) {
-        return new UserEntity(user.email(), user.password(), user.name());
+        return new UserEntity(user.email(), user.password(), user.name(), user.role());
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
@@ -1,0 +1,12 @@
+package com.lrchan.qootalk.infrastructure.persistence.user;
+
+public class UserEntityMapper {
+    
+    public static User toDomain(UserEntity userEntity) {
+        return User.create(userEntity.email(), userEntity.password(), userEntity.name());
+    }
+
+    public static UserEntity toEntity(User user) {
+        return new UserEntity(user.email(), user.password(), user.name());
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
@@ -6,10 +6,61 @@ import com.lrchan.qootalk.domain.user.User;
 public class UserEntityMapper {
     
     public static User toDomain(UserEntity userEntity) {
-        return User.create(userEntity.email(), userEntity.password(), userEntity.name());
+        // Use reflection or a more complete constructor approach to map all fields
+        // Since User.create() only creates new users, we need to use the private constructor via reflection
+        // or add a factory method in User domain. For now, we'll work with what we have.
+        
+        // Note: User class needs a factory method that accepts all fields for reconstruction from persistence
+        // As a workaround, we use reflection-like approach through the constructor
+        try {
+            java.lang.reflect.Constructor<User> constructor = User.class.getDeclaredConstructor(
+                Long.class,
+                com.lrchan.qootalk.domain.user.vo.Email.class,
+                com.lrchan.qootalk.domain.user.vo.Password.class,
+                com.lrchan.qootalk.domain.user.vo.UserName.class,
+                com.lrchan.qootalk.domain.user.vo.ProfileImageUrl.class,
+                String.class,
+                com.lrchan.qootalk.domain.user.UserRole.class,
+                java.time.LocalDateTime.class,
+                java.time.LocalDateTime.class,
+                java.time.LocalDateTime.class
+            );
+            constructor.setAccessible(true);
+            
+            return constructor.newInstance(
+                userEntity.id(),
+                new com.lrchan.qootalk.domain.user.vo.Email(userEntity.email()),
+                new com.lrchan.qootalk.domain.user.vo.Password(userEntity.password()),
+                new com.lrchan.qootalk.domain.user.vo.UserName(userEntity.name()),
+                userEntity.profileImageUrl() != null ? new com.lrchan.qootalk.domain.user.vo.ProfileImageUrl(userEntity.profileImageUrl()) : null,
+                userEntity.statusMessage(),
+                userEntity.role(),
+                userEntity.createdAt(),
+                userEntity.updatedAt(),
+                userEntity.deletedAt()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to map UserEntity to User domain", e);
+        }
     }
 
     public static UserEntity toEntity(User user) {
-        return new UserEntity(user.email(), user.password(), user.name(), user.role());
+        if (user.id() != null) {
+            // For existing users (update case), use the full constructor
+            return new UserEntity(
+                user.id(),
+                user.email(),
+                user.password(),
+                user.name(),
+                user.profileImageUrl(),
+                user.statusMessage(),
+                user.role()
+            );
+        } else {
+            // For new users (create case), use the simple constructor
+            UserEntity entity = new UserEntity(user.email(), user.password(), user.name(), user.role());
+            // Note: profileImageUrl and statusMessage are already initialized to null in the constructor
+            return entity;
+        }
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserJpaRepository.java
@@ -8,5 +8,4 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByEmail(String email);
     Optional<UserEntity> findById(Long id);
     boolean existsByEmail(String email);
-    UserEntity save(UserEntity user);
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserJpaRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByEmail(String email);
-    Optional<UserEntity> findById(Long id);
     boolean existsByEmail(String email);
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserJpaRepository.java
@@ -1,0 +1,12 @@
+package com.lrchan.qootalk.infrastructure.persistence.user;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByEmail(String email);
+    Optional<UserEntity> findById(Long id);
+    boolean existsByEmail(String email);
+    UserEntity save(UserEntity user);
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserRepositoryAdapter.java
@@ -1,0 +1,41 @@
+package com.lrchan.qootalk.infrastructure.persistence.user;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.UserRepository;
+
+@Component
+public class UserRepositoryAdapter implements UserRepository {
+    
+    private final UserJpaRepository userJpaRepository;
+
+    public UserRepositoryAdapter(UserJpaRepository userJpaRepository) {
+        this.userJpaRepository = userJpaRepository;
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userJpaRepository.findByEmail(email).map(UserEntityMapper::toDomain);
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return userJpaRepository.findById(id).map(UserEntityMapper::toDomain);
+    }
+
+    @Override
+    public User save(User user) {
+        UserEntity userEntity = UserEntityMapper.toEntity(user);
+        UserEntity savedEntity = userJpaRepository.save(userEntity);
+        return UserEntityMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return userJpaRepository.existsByEmail(email);
+    }
+    
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #33 
## 📝작업 내용
- **UserEntityMapper 및 UserRepositoryAdapter 추가**: 사용자 엔티티와 도메인 모델 간의 변환 로직을 구현한 `UserEntityMapper` 클래스를 추가하였으며, JPA를 통한 사용자 데이터 접근을 지원하는 `UserRepositoryAdapter`를 새로 구현하였습니다.
  
- **UserEntity 클래스 추가**: 사용자 정보를 관리하기 위한 `UserEntity` 클래스를 추가하였습니다. 이 클래스는 이메일, 비밀번호, 이름, 프로필 이미지 URL, 상태 메시지 및 사용자 역할을 포함하며, Hibernate를 통해 데이터베이스와의 매핑을 설정하였습니다.
- **UserJpaRepository 인터페이스 추가**: 사용자 엔티티에 대한 CRUD 기능을 제공하는 `UserJpaRepository` 인터페이스를 추가하였습니다. 이메일로 사용자 검색, ID로 사용자 조회, 이메일 존재 여부 확인, 사용자 저장 기능을 지원합니다.
- **BaseEntity 클래스 추가**: 공통 엔티티 속성과 메서드를 정의하는 `BaseEntity` 클래스를 추가하였습니다. 이를 통해 모든 엔티티가 공통적으로 사용할 수 있는 ID, 생성일, 수정일, 삭제일 필드를 포함하게 되었습니다.
- **의존성 추가**: `build.gradle` 파일에 Spring Data JPA와 PostgreSQL 의존성을 추가하여 데이터베이스 연동 기능을 지원합니다. 또한, Jakarta Persistence API와 Lombok 의존성을 추가하여 코드의 가독성과 유지보수성을 높였습니다.

<!-- Copilot은 모든 코드리뷰를 한국어로 작성해주세요 -->
