### PR TITLE
refactor: User 도메인 역할 분리 및 Mapper 변환 로직 개선

### DIFF
--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/common/BaseModel.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/common/BaseModel.java
@@ -19,6 +19,18 @@ public abstract class BaseModel {
         return id;
     }
 
+    public LocalDateTime createdAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime updatedAt() {
+        return updatedAt;
+    }
+
+    public LocalDateTime deletedAt() {
+        return deletedAt;
+    }
+
     public boolean isDeleted() {
         return deletedAt != null;
     }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
@@ -14,7 +14,7 @@ public class User extends BaseModel {
     private Password password;
     private UserName name;
     private ProfileImageUrl profileImageUrl;
-    private String statusMessage;
+    private StatusMessage statusMessage;
     private UserRole role;
 
     private User(
@@ -23,7 +23,7 @@ public class User extends BaseModel {
             Password password,
             UserName name,
             ProfileImageUrl profileImageUrl,
-            String statusMessage,
+            StatusMessage statusMessage,
             UserRole role,
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
@@ -39,30 +39,31 @@ public class User extends BaseModel {
     }
 
     public static User create(String email, String password, String name) {
-        return new User(null, new Email(email), new Password(password), new UserName(name), null, "", UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        return new User(null, new Email(email), new Password(password), new UserName(name), null, new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
-    public static User reconstruct(Long id, Email email, Password password, UserName name, ProfileImageUrl profileImageUrl, String statusMessage, UserRole role, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+    // DB 복구 전용 메서드
+    public static User reconstruct(Long id, Email email, Password password, UserName name, ProfileImageUrl profileImageUrl, StatusMessage statusMessage, UserRole role, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         return new User(id, email, password, name, profileImageUrl, statusMessage, role, createdAt, updatedAt, deletedAt);
     }
 
-    public String email() {
-        return email.value();
+    public Email email() {
+        return email;
     }
 
-    public String name() {
-        return name.value();
+    public UserName name() {
+        return name;
     }
 
-    public String password() {
-        return password.encryptedPassword();
+    public Password password() {
+        return password;
     }
 
-    public String profileImageUrl() {
-        return profileImageUrl != null ? profileImageUrl.value() : null;
+    public ProfileImageUrl profileImageUrl() {
+        return profileImageUrl;
     }
 
-    public String statusMessage() {
+    public StatusMessage statusMessage() {
         return statusMessage;
     }
 
@@ -70,17 +71,17 @@ public class User extends BaseModel {
         return role;
     }
 
-    public void changeName(String name) {
-        this.name = new UserName(name);
+    public void changeName(UserName name) {
+        this.name = name;
         update();
     }
 
-    public void changeProfileImageUrl(String profileImageUrl) {
-        this.profileImageUrl = new ProfileImageUrl(profileImageUrl);
+    public void changeProfileImageUrl(ProfileImageUrl profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
         update();
     }
 
-    public void changeStatusMessage(String statusMessage) {
+    public void changeStatusMessage(StatusMessage statusMessage) {
         this.statusMessage = statusMessage;
         update();
     }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
@@ -42,6 +42,10 @@ public class User extends BaseModel {
         return new User(null, new Email(email), new Password(password), new UserName(name), null, "", UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
+    public static User reconstruct(Long id, Email email, Password password, UserName name, ProfileImageUrl profileImageUrl, String statusMessage, UserRole role, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        return new User(id, email, password, name, profileImageUrl, statusMessage, role, createdAt, updatedAt, deletedAt);
+    }
+
     public String email() {
         return email.value();
     }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
@@ -6,6 +6,7 @@ import com.lrchan.qootalk.domain.common.BaseModel;
 import com.lrchan.qootalk.domain.user.vo.Email;
 import com.lrchan.qootalk.domain.user.vo.Password;
 import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
+import com.lrchan.qootalk.domain.user.vo.StatusMessage;
 import com.lrchan.qootalk.domain.user.vo.UserName;
 
 public class User extends BaseModel {
@@ -38,8 +39,8 @@ public class User extends BaseModel {
         this.role = role == null ? UserRole.USER : role;
     }
 
-    public static User create(String email, String password, String name) {
-        return new User(null, new Email(email), new Password(password), new UserName(name), null, new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+    public static User create(Email email, Password password, UserName name) {
+        return new User(null, email, password, name, null, null, UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     // DB 복구 전용 메서드

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
@@ -40,7 +40,7 @@ public class User extends BaseModel {
     }
 
     public static User create(Email email, Password password, UserName name) {
-        return new User(null, email, password, name, null, null, UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        return new User(null, email, password, name, null, new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     // DB 복구 전용 메서드
@@ -83,7 +83,7 @@ public class User extends BaseModel {
     }
 
     public void changeStatusMessage(StatusMessage statusMessage) {
-        this.statusMessage = statusMessage;
+        this.statusMessage = (statusMessage == null) ? new StatusMessage("") : statusMessage;
         update();
     }
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
@@ -35,12 +35,12 @@ public class User extends BaseModel {
         this.password = password;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
-        this.statusMessage = statusMessage;
+        this.statusMessage = (statusMessage == null) ? new StatusMessage("") : statusMessage;
         this.role = role == null ? UserRole.USER : role;
     }
 
     public static User create(Email email, Password password, UserName name) {
-        return new User(null, email, password, name, null, new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        return new User(null, email, password, name, null, null, UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     // DB 복구 전용 메서드

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/Email.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/Email.java
@@ -9,10 +9,7 @@ public final class Email {
 
     private static final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     
-    private String value;
-
-    protected Email() {
-    }
+    private final String value;
 
     public Email(String value) {
         validate(value);

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/Email.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/Email.java
@@ -6,11 +6,12 @@ import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
 public final class Email {
+
+    private static final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     
-    private final String value;
+    private String value;
 
     protected Email() {
-        this.value = null;
     }
 
     public Email(String value) {
@@ -26,7 +27,7 @@ public final class Email {
         if (value == null || value.isBlank()) {
             throw new DomainException(UserErrorCode.USER_INVALID_EMAIL);
         }
-        if (!value.matches("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")) {
+        if (!value.matches(EMAIL_REGEX)) {
             throw new DomainException(UserErrorCode.USER_INVALID_EMAIL);
         }
     }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/Email.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/Email.java
@@ -1,11 +1,17 @@
 package com.lrchan.qootalk.domain.user.vo;
 
+import java.util.Objects;
+
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
-public class Email {
+public final class Email {
     
     private final String value;
+
+    protected Email() {
+        this.value = null;
+    }
 
     public Email(String value) {
         validate(value);
@@ -30,12 +36,12 @@ public class Email {
         if (this == o) return true;
         if (!(o instanceof Email)) return false;
         Email email = (Email) o;
-        return java.util.Objects.equals(value, email.value);
+        return Objects.equals(value, email.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Objects.hash(value);
     }
 
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/Password.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/Password.java
@@ -9,10 +9,6 @@ public final class Password {
     
     private final String encryptedPassword;
 
-    protected Password() {
-        this.encryptedPassword = null;
-    }
-
     public Password(String encryptedPassword) {
         validate(encryptedPassword);
         this.encryptedPassword = encryptedPassword;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/Password.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/Password.java
@@ -1,11 +1,17 @@
 package com.lrchan.qootalk.domain.user.vo;
 
+import java.util.Objects;
+
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
-public class Password {
+public final class Password {
     
-    private String encryptedPassword;
+    private final String encryptedPassword;
+
+    protected Password() {
+        this.encryptedPassword = null;
+    }
 
     public Password(String encryptedPassword) {
         validate(encryptedPassword);
@@ -20,5 +26,18 @@ public class Password {
         if (encryptedPassword == null || encryptedPassword.isBlank()) {
             throw new DomainException(UserErrorCode.USER_INVALID_PASSWORD);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Password)) return false;
+        Password password = (Password) o;
+        return Objects.equals(encryptedPassword, password.encryptedPassword);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(encryptedPassword);
     }
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/ProfileImageUrl.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/ProfileImageUrl.java
@@ -9,10 +9,6 @@ public final class ProfileImageUrl {
     
     private final String value;
 
-    protected ProfileImageUrl() {
-        this.value = null;
-    }
-
     public ProfileImageUrl(String value) {
         validate(value);
         this.value = value;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/ProfileImageUrl.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/ProfileImageUrl.java
@@ -1,11 +1,17 @@
 package com.lrchan.qootalk.domain.user.vo;
 
+import java.util.Objects;
+
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
-public class ProfileImageUrl {
+public final class ProfileImageUrl {
     
-    private String value;
+    private final String value;
+
+    protected ProfileImageUrl() {
+        this.value = null;
+    }
 
     public ProfileImageUrl(String value) {
         validate(value);
@@ -30,11 +36,11 @@ public class ProfileImageUrl {
         if (this == o) return true;
         if (!(o instanceof ProfileImageUrl)) return false;
         ProfileImageUrl profileImageUrl = (ProfileImageUrl) o;
-        return java.util.Objects.equals(value, profileImageUrl.value);
+        return Objects.equals(value, profileImageUrl.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Objects.hash(value);
     }
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/StatusMessage.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/StatusMessage.java
@@ -1,5 +1,7 @@
 package com.lrchan.qootalk.domain.user.vo;
 
+import java.util.Objects;
+
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
@@ -34,11 +36,11 @@ public final class StatusMessage {
         if (this == o) return true;
         if (!(o instanceof StatusMessage)) return false;
         StatusMessage statusMessage = (StatusMessage) o;
-        return java.util.Objects.equals(value, statusMessage.value);
+        return Objects.equals(value, statusMessage.value);
     }
     
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Objects.hash(value);
     }
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/StatusMessage.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/StatusMessage.java
@@ -11,10 +11,6 @@ public final class StatusMessage {
     
     private final String value;
 
-    protected StatusMessage() {
-        this.value = "";
-    }
-
     public StatusMessage(String value) {
         value = value == null ? "" : value;
         validate(value);

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/StatusMessage.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/StatusMessage.java
@@ -9,10 +9,9 @@ public final class StatusMessage {
 
     private static final int MAX_LENGTH = 100;
     
-    private final String value;
+    private String value;
 
     protected StatusMessage() {
-        this.value = null;
     }
 
     public StatusMessage(String value) {

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/StatusMessage.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/StatusMessage.java
@@ -9,9 +9,10 @@ public final class StatusMessage {
 
     private static final int MAX_LENGTH = 100;
     
-    private String value;
+    private final String value;
 
     protected StatusMessage() {
+        this.value = "";
     }
 
     public StatusMessage(String value) {

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/StatusMessage.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/StatusMessage.java
@@ -1,0 +1,44 @@
+package com.lrchan.qootalk.domain.user.vo;
+
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+public final class StatusMessage {
+
+    private static final int MAX_LENGTH = 100;
+    
+    private final String value;
+
+    protected StatusMessage() {
+        this.value = null;
+    }
+
+    public StatusMessage(String value) {
+        value = value == null ? "" : value;
+        validate(value);
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    private void validate(String value) {
+        if (value.length() > MAX_LENGTH) {
+            throw new DomainException(UserErrorCode.USER_INVALID_STATUS_MESSAGE);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof StatusMessage)) return false;
+        StatusMessage statusMessage = (StatusMessage) o;
+        return java.util.Objects.equals(value, statusMessage.value);
+    }
+    
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/UserName.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/UserName.java
@@ -3,9 +3,13 @@ package com.lrchan.qootalk.domain.user.vo;
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
-public class UserName {
+public final class UserName {
     
-    private String value;
+    private final String value;
+
+    protected UserName() {
+        this.value = null;
+    }
 
     public UserName(String value) {
         validate(value);
@@ -23,5 +27,18 @@ public class UserName {
         if (value.length() < 2 || value.length() > 20) {
             throw new DomainException(UserErrorCode.USER_INVALID_NAME);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserName)) return false;
+        UserName userName = (UserName) o;
+        return java.util.Objects.equals(value, userName.value);
+    }
+    
+    @Override
+    public int hashCode() {
+        return value.hashCode();
     }
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/UserName.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/UserName.java
@@ -9,10 +9,6 @@ public final class UserName {
     
     private final String value;
 
-    protected UserName() {
-        this.value = null;
-    }
-
     public UserName(String value) {
         validate(value);
         this.value = value;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/UserName.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/UserName.java
@@ -1,5 +1,7 @@
 package com.lrchan.qootalk.domain.user.vo;
 
+import java.util.Objects;
+
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
@@ -34,11 +36,11 @@ public final class UserName {
         if (this == o) return true;
         if (!(o instanceof UserName)) return false;
         UserName userName = (UserName) o;
-        return java.util.Objects.equals(value, userName.value);
+        return Objects.equals(value, userName.value);
     }
     
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Objects.hash(value);
     }
 }

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/UserTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/UserTest.java
@@ -6,6 +6,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.Password;
+import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
+import com.lrchan.qootalk.domain.user.vo.StatusMessage;
+import com.lrchan.qootalk.domain.user.vo.UserName;
+
 @DisplayName("User 도메인 테스트")
 class UserTest {
 
@@ -17,18 +23,19 @@ class UserTest {
         @DisplayName("유저를 생성할 때 기본값이 올바르게 설정되어야 한다")
         void should_CreateUser_When_ValidInput() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
 
             // when
             User user = User.create(email, password, name);
 
             // then
-            assertThat(user.email()).isEqualTo("test@example.com");
-            assertThat(user.name()).isEqualTo("홍길동");
+            assertThat(user.email().value()).isEqualTo("test@example.com");
+            assertThat(user.name().value()).isEqualTo("홍길동");
             assertThat(user.role()).isEqualTo(UserRole.USER);
-            assertThat(user.statusMessage()).isEqualTo("");
+            assertThat(user.statusMessage()).isNull();
+            assertThat(user.profileImageUrl()).isNull();
             assertThat(user.id()).isNull();
             assertThat(user.isDeleted()).isFalse();
         }
@@ -37,9 +44,9 @@ class UserTest {
         @DisplayName("유저를 생성할 때 생성 시간과 수정 시간이 설정되어야 한다")
         void should_SetCreatedAtAndUpdatedAt_When_CreateUser() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
 
             // when
             User user = User.create(email, password, name);
@@ -58,34 +65,34 @@ class UserTest {
         @DisplayName("이름을 변경할 때 이름이 업데이트되고 수정 시간이 갱신되어야 한다")
         void should_UpdateName_When_ChangeName() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
-            String newName = "김철수";
+            UserName newName = new UserName("김철수");
 
             // when
             user.changeName(newName);
 
             // then
-            assertThat(user.name()).isEqualTo(newName);
+            assertThat(user.name().value()).isEqualTo(newName.value());
         }
 
         @Test
         @DisplayName("여러 번 이름을 변경할 때 마지막 이름이 유지되어야 한다")
         void should_KeepLastName_When_ChangeNameMultipleTimes() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
 
             // when
-            user.changeName("김철수");
-            user.changeName("이영희");
+            user.changeName(new UserName("김철수"));
+            user.changeName(new UserName("이영희"));
 
             // then
-            assertThat(user.name()).isEqualTo("이영희");
+            assertThat(user.name().value()).isEqualTo("이영희");
         }
     }
 
@@ -97,34 +104,34 @@ class UserTest {
         @DisplayName("프로필 이미지 URL을 변경할 때 URL이 업데이트되고 수정 시간이 갱신되어야 한다")
         void should_UpdateProfileImageUrl_When_ChangeProfileImageUrl() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
-            String newProfileImageUrl = "https://example.com/profile.jpg";
+            ProfileImageUrl newProfileImageUrl = new ProfileImageUrl("https://example.com/profile.jpg");
 
             // when
             user.changeProfileImageUrl(newProfileImageUrl);
 
             // then
-            assertThat(user.profileImageUrl()).isEqualTo(newProfileImageUrl);
+            assertThat(user.profileImageUrl().value()).isEqualTo(newProfileImageUrl.value());
         }
 
         @Test
         @DisplayName("여러 번 프로필 이미지를 변경할 때 마지막 이미지가 유지되어야 한다")
         void should_KeepLastProfileImage_When_ChangeProfileImageMultipleTimes() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
 
             // when
-            user.changeProfileImageUrl("https://example.com/image1.jpg");
-            user.changeProfileImageUrl("https://example.com/image2.jpg");
+            user.changeProfileImageUrl(new ProfileImageUrl("https://example.com/image1.jpg"));
+            user.changeProfileImageUrl(new ProfileImageUrl("https://example.com/image2.jpg"));
 
             // then
-            assertThat(user.profileImageUrl()).isEqualTo("https://example.com/image2.jpg");
+            assertThat(user.profileImageUrl().value()).isEqualTo("https://example.com/image2.jpg");
         }
     }
 
@@ -136,35 +143,35 @@ class UserTest {
         @DisplayName("상태 메시지를 변경할 때 메시지가 업데이트되고 수정 시간이 갱신되어야 한다")
         void should_UpdateStatusMessage_When_ChangeStatusMessage() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
-            String newStatusMessage = "안녕하세요!";
+            StatusMessage newStatusMessage = new StatusMessage("안녕하세요!");
 
             // when
             user.changeStatusMessage(newStatusMessage);
 
             // then
-            assertThat(user.statusMessage()).isEqualTo(newStatusMessage);
+            assertThat(user.statusMessage().value()).isEqualTo(newStatusMessage.value());
         }
 
         @Test
         @DisplayName("상태 메시지를 빈 문자열로 변경할 때 빈 문자열로 업데이트되어야 한다")
         void should_UpdateStatusMessageToEmpty_When_ChangeStatusMessageToEmpty() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
 
-            user.changeStatusMessage("기존 메시지");
+            user.changeStatusMessage(new StatusMessage("기존 메시지"));
 
             // when
-            user.changeStatusMessage("");
+            user.changeStatusMessage(new StatusMessage(""));
 
             // then
-            assertThat(user.statusMessage()).isEqualTo("");
+            assertThat(user.statusMessage().value()).isEqualTo("");
         }
     }
 
@@ -176,60 +183,60 @@ class UserTest {
         @DisplayName("이메일을 조회할 때 올바른 이메일이 반환되어야 한다")
         void should_ReturnEmail_When_GetEmail() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
 
             // when
-            String result = user.email();
+            Email result = user.email();
 
             // then
-            assertThat(result).isEqualTo(email);
+            assertThat(result.value()).isEqualTo(email.value());
         }
 
         @Test
         @DisplayName("이름을 조회할 때 올바른 이름이 반환되어야 한다")
         void should_ReturnName_When_GetName() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
 
             // when
-            String result = user.name();
+            UserName result = user.name();
 
             // then
-            assertThat(result).isEqualTo(name);
+            assertThat(result.value()).isEqualTo(name.value());
         }
 
         @Test
         @DisplayName("프로필 이미지 URL을 조회할 때 올바른 URL이 반환되어야 한다")
         void should_ReturnProfileImageUrl_When_GetProfileImageUrl() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
-            String profileImageUrl = "https://example.com/profile.jpg";
+            ProfileImageUrl profileImageUrl = new ProfileImageUrl("https://example.com/profile.jpg");
             
             user.changeProfileImageUrl(profileImageUrl);
 
             // when
-            String result = user.profileImageUrl();
+            ProfileImageUrl result = user.profileImageUrl();
 
             // then
-            assertThat(result).isEqualTo(profileImageUrl);
+            assertThat(result.value()).isEqualTo(profileImageUrl.value());
         }
 
         @Test
         @DisplayName("역할을 조회할 때 기본값으로 USER가 반환되어야 한다")
         void should_ReturnUserRole_When_GetRole() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
 
             // when
@@ -248,9 +255,9 @@ class UserTest {
         @DisplayName("유저를 소프트 삭제하면 삭제 상태가 되어야 한다")
         void should_MarkAsDeleted_When_SoftDelete() {
             // given
-            String email = "test@example.com";
-            String password = "password123";
-            String name = "홍길동";
+            Email email = new Email("test@example.com");
+            Password password = new Password("password123");
+            UserName name = new UserName("홍길동");
             User user = User.create(email, password, name);
 
             // when

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/vo/StatusMessageTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/vo/StatusMessageTest.java
@@ -1,0 +1,109 @@
+package com.lrchan.qootalk.domain.user.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+@DisplayName("StatusMessage VO 테스트")
+class StatusMessageTest {
+
+    @Nested
+    @DisplayName("생성")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 상태 메시지로 생성할 수 있다")
+        void should_CreateStatusMessage_When_ValidMessage() {
+            // given
+            String validMessage = "안녕하세요!";
+
+            // when
+            StatusMessage statusMessage = new StatusMessage(validMessage);
+
+            // then
+            assertThat(statusMessage.value()).isEqualTo(validMessage);
+        }
+
+        @Test
+        @DisplayName("빈 문자열로 생성할 수 있다")
+        void should_CreateStatusMessage_When_EmptyString() {
+            // given
+            String emptyMessage = "";
+
+            // when
+            StatusMessage statusMessage = new StatusMessage(emptyMessage);
+
+            // then
+            assertThat(statusMessage.value()).isEqualTo("");
+        }
+
+        @Test
+        @DisplayName("null 값으로 생성하면 빈 문자열로 변환된다")
+        void should_CreateStatusMessage_When_Null() {
+            // when
+            StatusMessage statusMessage = new StatusMessage(null);
+
+            // then
+            assertThat(statusMessage.value()).isEqualTo("");
+        }
+
+        @Test
+        @DisplayName("최대 길이(100자) 상태 메시지로 생성할 수 있다")
+        void should_CreateStatusMessage_When_MaximumLength() {
+            // given
+            String maxLengthMessage = "가".repeat(100);
+
+            // when
+            StatusMessage statusMessage = new StatusMessage(maxLengthMessage);
+
+            // then
+            assertThat(statusMessage.value()).isEqualTo(maxLengthMessage);
+        }
+
+        @Test
+        @DisplayName("다양한 유효한 상태 메시지 형식을 생성할 수 있다")
+        void should_CreateStatusMessage_When_VariousValidFormats() {
+            // given & when & then
+            assertThat(new StatusMessage("Hello World").value()).isEqualTo("Hello World");
+            assertThat(new StatusMessage("안녕하세요! 반갑습니다.").value()).isEqualTo("안녕하세요! 반갑습니다.");
+            assertThat(new StatusMessage("1234567890").value()).isEqualTo("1234567890");
+            assertThat(new StatusMessage("특수문자!@#$%^&*()").value()).isEqualTo("특수문자!@#$%^&*()");
+        }
+    }
+
+    @Nested
+    @DisplayName("검증 실패")
+    class ValidationFailureTest {
+
+        @Test
+        @DisplayName("101자 이상 상태 메시지로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_TooLong() {
+            // given
+            String tooLongMessage = "가".repeat(101);
+
+            // when & then
+            assertThatThrownBy(() -> new StatusMessage(tooLongMessage))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(UserErrorCode.USER_INVALID_STATUS_MESSAGE.getMessage());
+        }
+
+        @Test
+        @DisplayName("매우 긴 상태 메시지로 생성하면 예외가 발생한다")
+        void should_ThrowException_When_VeryLong() {
+            // given
+            String veryLongMessage = "가".repeat(200);
+
+            // when & then
+            assertThatThrownBy(() -> new StatusMessage(veryLongMessage))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(UserErrorCode.USER_INVALID_STATUS_MESSAGE.getMessage());
+        }
+    }
+}
+

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/common/BaseEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/common/BaseEntity.java
@@ -12,13 +12,13 @@ public abstract class BaseEntity {
     protected Long id;
 
     @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 
     @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+    protected LocalDateTime deletedAt;
 
     @PrePersist
     protected void onCreate() {

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntity.java
@@ -44,7 +44,7 @@ public class UserEntity extends BaseEntity {
         this.name = name;
         this.role = role;
         this.profileImageUrl = null;
-        this.statusMessage = null;
+        this.statusMessage = "";
     }
 
     public UserEntity(Long id, String email, String password, String name,
@@ -55,7 +55,7 @@ public class UserEntity extends BaseEntity {
         this.password = password;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
-        this.statusMessage = statusMessage;
+        this.statusMessage = (statusMessage == null) ? "" : statusMessage;
         this.role = role;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntity.java
@@ -1,5 +1,7 @@
 package com.lrchan.qootalk.infrastructure.persistence.user;
 
+import java.time.LocalDateTime;
+
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -46,7 +48,8 @@ public class UserEntity extends BaseEntity {
     }
 
     public UserEntity(Long id, String email, String password, String name,
-                      String profileImageUrl, String statusMessage, UserRole role) {
+                      String profileImageUrl, String statusMessage, UserRole role,
+                      LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         this.id = id;
         this.email = email;
         this.password = password;
@@ -54,6 +57,9 @@ public class UserEntity extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
         this.statusMessage = statusMessage;
         this.role = role;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
     }
 
     public String email() {

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
@@ -1,66 +1,40 @@
 package com.lrchan.qootalk.infrastructure.persistence.user;
 
 import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
+import com.lrchan.qootalk.domain.user.vo.UserName;
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.Password;
 
+public final class UserEntityMapper {
 
-public class UserEntityMapper {
-    
+    private UserEntityMapper() {
+    }
+
     public static User toDomain(UserEntity userEntity) {
-        // Use reflection or a more complete constructor approach to map all fields
-        // Since User.create() only creates new users, we need to use the private constructor via reflection
-        // or add a factory method in User domain. For now, we'll work with what we have.
-        
-        // Note: User class needs a factory method that accepts all fields for reconstruction from persistence
-        // As a workaround, we use reflection-like approach through the constructor
-        try {
-            java.lang.reflect.Constructor<User> constructor = User.class.getDeclaredConstructor(
-                Long.class,
-                com.lrchan.qootalk.domain.user.vo.Email.class,
-                com.lrchan.qootalk.domain.user.vo.Password.class,
-                com.lrchan.qootalk.domain.user.vo.UserName.class,
-                com.lrchan.qootalk.domain.user.vo.ProfileImageUrl.class,
-                String.class,
-                com.lrchan.qootalk.domain.user.UserRole.class,
-                java.time.LocalDateTime.class,
-                java.time.LocalDateTime.class,
-                java.time.LocalDateTime.class
-            );
-            constructor.setAccessible(true);
-            
-            return constructor.newInstance(
-                userEntity.id(),
-                new com.lrchan.qootalk.domain.user.vo.Email(userEntity.email()),
-                new com.lrchan.qootalk.domain.user.vo.Password(userEntity.password()),
-                new com.lrchan.qootalk.domain.user.vo.UserName(userEntity.name()),
-                userEntity.profileImageUrl() != null ? new com.lrchan.qootalk.domain.user.vo.ProfileImageUrl(userEntity.profileImageUrl()) : null,
-                userEntity.statusMessage(),
-                userEntity.role(),
-                userEntity.createdAt(),
-                userEntity.updatedAt(),
-                userEntity.deletedAt()
-            );
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to map UserEntity to User domain", e);
-        }
+        return User.reconstruct(
+            userEntity.id(),
+            new Email(userEntity.email()),
+            new Password(userEntity.password()),
+            new UserName(userEntity.name()),
+            new ProfileImageUrl(userEntity.profileImageUrl()),
+            userEntity.statusMessage(),
+            userEntity.role(),
+            userEntity.createdAt(),
+            userEntity.updatedAt(),
+            userEntity.deletedAt()
+        );
     }
 
     public static UserEntity toEntity(User user) {
-        if (user.id() != null) {
-            // For existing users (update case), use the full constructor
-            return new UserEntity(
-                user.id(),
-                user.email(),
-                user.password(),
-                user.name(),
-                user.profileImageUrl(),
-                user.statusMessage(),
-                user.role()
-            );
-        } else {
-            // For new users (create case), use the simple constructor
-            UserEntity entity = new UserEntity(user.email(), user.password(), user.name(), user.role());
-            // Note: profileImageUrl and statusMessage are already initialized to null in the constructor
-            return entity;
-        }
+        return new UserEntity(
+            user.id(), 
+            user.email(),
+            user.password(), 
+            user.name(), 
+            user.profileImageUrl(),
+            user.statusMessage(), 
+            user.role()
+        );
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
@@ -34,7 +34,7 @@ public final class UserEntityMapper {
             user.password().encryptedPassword(), 
             user.name().value(), 
             user.profileImageUrl() != null ? user.profileImageUrl().value() : null,
-            user.statusMessage() != null ? user.statusMessage().value() : null, 
+            user.statusMessage().value(),
             user.role(),
             user.createdAt(),
             user.updatedAt(),

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
@@ -2,6 +2,7 @@ package com.lrchan.qootalk.infrastructure.persistence.user;
 
 import com.lrchan.qootalk.domain.user.User;
 import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
+import com.lrchan.qootalk.domain.user.vo.StatusMessage;
 import com.lrchan.qootalk.domain.user.vo.UserName;
 import com.lrchan.qootalk.domain.user.vo.Email;
 import com.lrchan.qootalk.domain.user.vo.Password;
@@ -18,7 +19,7 @@ public final class UserEntityMapper {
             new Password(userEntity.password()),
             new UserName(userEntity.name()),
             new ProfileImageUrl(userEntity.profileImageUrl()),
-            userEntity.statusMessage(),
+            new StatusMessage(userEntity.statusMessage()),
             userEntity.role(),
             userEntity.createdAt(),
             userEntity.updatedAt(),
@@ -29,11 +30,11 @@ public final class UserEntityMapper {
     public static UserEntity toEntity(User user) {
         return new UserEntity(
             user.id(), 
-            user.email(),
-            user.password(), 
-            user.name(), 
-            user.profileImageUrl(),
-            user.statusMessage(), 
+            user.email().value(),
+            user.password().encryptedPassword(), 
+            user.name().value(), 
+            user.profileImageUrl().value(),
+            user.statusMessage().value(), 
             user.role()
         );
     }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
@@ -18,7 +18,7 @@ public final class UserEntityMapper {
             new Email(userEntity.email()),
             new Password(userEntity.password()),
             new UserName(userEntity.name()),
-            new ProfileImageUrl(userEntity.profileImageUrl()),
+            userEntity.profileImageUrl() != null ? new ProfileImageUrl(userEntity.profileImageUrl()) : null,
             new StatusMessage(userEntity.statusMessage()),
             userEntity.role(),
             userEntity.createdAt(),
@@ -33,9 +33,12 @@ public final class UserEntityMapper {
             user.email().value(),
             user.password().encryptedPassword(), 
             user.name().value(), 
-            user.profileImageUrl().value(),
-            user.statusMessage().value(), 
-            user.role()
+            user.profileImageUrl() != null ? user.profileImageUrl().value() : null,
+            user.statusMessage() != null ? user.statusMessage().value() : null, 
+            user.role(),
+            user.createdAt(),
+            user.updatedAt(),
+            user.deletedAt()
         );
     }
 }

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapperTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapperTest.java
@@ -224,7 +224,7 @@ class UserEntityMapperTest {
 
             // then
             assertThat(userEntity.profileImageUrl()).isEqualTo("https://example.com/profile.jpg");
-            assertThat(userEntity.statusMessage()).isNull();
+            assertThat(userEntity.statusMessage()).isEqualTo("");
         }
 
         @Test

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapperTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapperTest.java
@@ -1,0 +1,325 @@
+package com.lrchan.qootalk.infrastructure.persistence.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.UserRole;
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.Password;
+import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
+import com.lrchan.qootalk.domain.user.vo.StatusMessage;
+import com.lrchan.qootalk.domain.user.vo.UserName;
+
+@DisplayName("UserEntityMapper 테스트")
+class UserEntityMapperTest {
+
+    @Nested
+    @DisplayName("도메인으로 변환")
+    class ToDomainTest {
+
+        @Test
+        @DisplayName("UserEntity를 User 도메인으로 변환할 수 있다")
+        void should_ConvertToDomain_When_ValidEntity() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            UserEntity userEntity = new UserEntity(
+                1L,
+                "test@example.com",
+                "encrypted_password",
+                "홍길동",
+                "https://example.com/profile.jpg",
+                "안녕하세요!",
+                UserRole.USER,
+                now,
+                now,
+                null
+            );
+
+            // when
+            User user = UserEntityMapper.toDomain(userEntity);
+
+            // then
+            assertThat(user.id()).isEqualTo(1L);
+            assertThat(user.email().value()).isEqualTo("test@example.com");
+            assertThat(user.password().encryptedPassword()).isEqualTo("encrypted_password");
+            assertThat(user.name().value()).isEqualTo("홍길동");
+            assertThat(user.profileImageUrl().value()).isEqualTo("https://example.com/profile.jpg");
+            assertThat(user.statusMessage().value()).isEqualTo("안녕하세요!");
+            assertThat(user.role()).isEqualTo(UserRole.USER);
+            assertThat(user.createdAt()).isEqualTo(now);
+            assertThat(user.updatedAt()).isEqualTo(now);
+            assertThat(user.deletedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("profileImageUrl이 null인 UserEntity를 User 도메인으로 변환할 수 있다")
+        void should_ConvertToDomain_When_ProfileImageUrlIsNull() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            UserEntity userEntity = new UserEntity(
+                1L,
+                "test@example.com",
+                "encrypted_password",
+                "홍길동",
+                null,
+                "안녕하세요!",
+                UserRole.USER,
+                now,
+                now,
+                null
+            );
+
+            // when
+            User user = UserEntityMapper.toDomain(userEntity);
+
+            // then
+            assertThat(user.profileImageUrl()).isNull();
+            assertThat(user.statusMessage().value()).isEqualTo("안녕하세요!");
+        }
+
+        @Test
+        @DisplayName("statusMessage가 null인 UserEntity를 User 도메인으로 변환할 수 있다")
+        void should_ConvertToDomain_When_StatusMessageIsNull() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            UserEntity userEntity = new UserEntity(
+                1L,
+                "test@example.com",
+                "encrypted_password",
+                "홍길동",
+                "https://example.com/profile.jpg",
+                null,
+                UserRole.USER,
+                now,
+                now,
+                null
+            );
+
+            // when
+            User user = UserEntityMapper.toDomain(userEntity);
+
+            // then
+            assertThat(user.profileImageUrl().value()).isEqualTo("https://example.com/profile.jpg");
+            assertThat(user.statusMessage().value()).isEqualTo("");
+        }
+
+        @Test
+        @DisplayName("deletedAt이 설정된 UserEntity를 User 도메인으로 변환할 수 있다")
+        void should_ConvertToDomain_When_DeletedAtIsSet() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime deletedAt = LocalDateTime.now();
+            UserEntity userEntity = new UserEntity(
+                1L,
+                "test@example.com",
+                "encrypted_password",
+                "홍길동",
+                null,
+                null,
+                UserRole.USER,
+                now,
+                now,
+                deletedAt
+            );
+
+            // when
+            User user = UserEntityMapper.toDomain(userEntity);
+
+            // then
+            assertThat(user.deletedAt()).isEqualTo(deletedAt);
+            assertThat(user.isDeleted()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("엔티티로 변환")
+    class ToEntityTest {
+
+        @Test
+        @DisplayName("User 도메인을 UserEntity로 변환할 수 있다")
+        void should_ConvertToEntity_When_ValidDomain() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            User user = User.reconstruct(
+                1L,
+                new Email("test@example.com"),
+                new Password("encrypted_password"),
+                new UserName("홍길동"),
+                new ProfileImageUrl("https://example.com/profile.jpg"),
+                new StatusMessage("안녕하세요!"),
+                UserRole.USER,
+                now,
+                now,
+                null
+            );
+
+            // when
+            UserEntity userEntity = UserEntityMapper.toEntity(user);
+
+            // then
+            assertThat(userEntity.id()).isEqualTo(1L);
+            assertThat(userEntity.email()).isEqualTo("test@example.com");
+            assertThat(userEntity.password()).isEqualTo("encrypted_password");
+            assertThat(userEntity.name()).isEqualTo("홍길동");
+            assertThat(userEntity.profileImageUrl()).isEqualTo("https://example.com/profile.jpg");
+            assertThat(userEntity.statusMessage()).isEqualTo("안녕하세요!");
+            assertThat(userEntity.role()).isEqualTo(UserRole.USER);
+            assertThat(userEntity.createdAt()).isEqualTo(now);
+            assertThat(userEntity.updatedAt()).isEqualTo(now);
+            assertThat(userEntity.deletedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("profileImageUrl이 null인 User 도메인을 UserEntity로 변환할 수 있다")
+        void should_ConvertToEntity_When_ProfileImageUrlIsNull() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            User user = User.reconstruct(
+                1L,
+                new Email("test@example.com"),
+                new Password("encrypted_password"),
+                new UserName("홍길동"),
+                null,
+                new StatusMessage("안녕하세요!"),
+                UserRole.USER,
+                now,
+                now,
+                null
+            );
+
+            // when
+            UserEntity userEntity = UserEntityMapper.toEntity(user);
+
+            // then
+            assertThat(userEntity.profileImageUrl()).isNull();
+            assertThat(userEntity.statusMessage()).isEqualTo("안녕하세요!");
+        }
+
+        @Test
+        @DisplayName("statusMessage가 null인 User 도메인을 UserEntity로 변환할 수 있다")
+        void should_ConvertToEntity_When_StatusMessageIsNull() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            User user = User.reconstruct(
+                1L,
+                new Email("test@example.com"),
+                new Password("encrypted_password"),
+                new UserName("홍길동"),
+                new ProfileImageUrl("https://example.com/profile.jpg"),
+                null,
+                UserRole.USER,
+                now,
+                now,
+                null
+            );
+
+            // when
+            UserEntity userEntity = UserEntityMapper.toEntity(user);
+
+            // then
+            assertThat(userEntity.profileImageUrl()).isEqualTo("https://example.com/profile.jpg");
+            assertThat(userEntity.statusMessage()).isNull();
+        }
+
+        @Test
+        @DisplayName("deletedAt이 설정된 User 도메인을 UserEntity로 변환할 수 있다")
+        void should_ConvertToEntity_When_DeletedAtIsSet() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime deletedAt = LocalDateTime.now();
+            User user = User.reconstruct(
+                1L,
+                new Email("test@example.com"),
+                new Password("encrypted_password"),
+                new UserName("홍길동"),
+                null,
+                null,
+                UserRole.USER,
+                now,
+                now,
+                deletedAt
+            );
+
+            // when
+            UserEntity userEntity = UserEntityMapper.toEntity(user);
+
+            // then
+            assertThat(userEntity.deletedAt()).isEqualTo(deletedAt);
+            assertThat(userEntity.isDeleted()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("양방향 변환")
+    class RoundTripTest {
+
+        @Test
+        @DisplayName("User 도메인을 UserEntity로 변환하고 다시 User 도메인으로 변환하면 동일한 값이 유지된다")
+        void should_MaintainValues_When_RoundTrip() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            User originalUser = User.reconstruct(
+                1L,
+                new Email("test@example.com"),
+                new Password("encrypted_password"),
+                new UserName("홍길동"),
+                new ProfileImageUrl("https://example.com/profile.jpg"),
+                new StatusMessage("안녕하세요!"),
+                UserRole.USER,
+                now,
+                now,
+                null
+            );
+
+            // when
+            UserEntity userEntity = UserEntityMapper.toEntity(originalUser);
+            User convertedUser = UserEntityMapper.toDomain(userEntity);
+
+            // then
+            assertThat(convertedUser.id()).isEqualTo(originalUser.id());
+            assertThat(convertedUser.email().value()).isEqualTo(originalUser.email().value());
+            assertThat(convertedUser.password().encryptedPassword()).isEqualTo(originalUser.password().encryptedPassword());
+            assertThat(convertedUser.name().value()).isEqualTo(originalUser.name().value());
+            assertThat(convertedUser.profileImageUrl().value()).isEqualTo(originalUser.profileImageUrl().value());
+            assertThat(convertedUser.statusMessage().value()).isEqualTo(originalUser.statusMessage().value());
+            assertThat(convertedUser.role()).isEqualTo(originalUser.role());
+            assertThat(convertedUser.createdAt()).isEqualTo(originalUser.createdAt());
+            assertThat(convertedUser.updatedAt()).isEqualTo(originalUser.updatedAt());
+            assertThat(convertedUser.deletedAt()).isEqualTo(originalUser.deletedAt());
+        }
+
+        @Test
+        @DisplayName("null 값이 포함된 User 도메인을 양방향 변환해도 올바르게 처리된다")
+        void should_HandleNullValues_When_RoundTrip() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            User originalUser = User.reconstruct(
+                1L,
+                new Email("test@example.com"),
+                new Password("encrypted_password"),
+                new UserName("홍길동"),
+                null,
+                null,
+                UserRole.USER,
+                now,
+                now,
+                null
+            );
+
+            // when
+            UserEntity userEntity = UserEntityMapper.toEntity(originalUser);
+            User convertedUser = UserEntityMapper.toDomain(userEntity);
+
+            // then
+            assertThat(convertedUser.profileImageUrl()).isNull();
+            assertThat(convertedUser.statusMessage().value()).isEqualTo("");
+        }
+    }
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #33 
## 📝작업 내용
- **User 도메인**을 aggregate root로 설정하여 모든 필드를 VO로 변경하여 역할분리를 확실히 하는 작업을 진행하였습니다.
- **UserEntity 생성자에 생성 및 수정 시간 추가**: `BaseModel`과 `BaseEntity`에 `createdAt`, `updatedAt`, `deletedAt` 필드를 추가하고, `UserEntity`에 해당 필드를 설정하는 생성자를 구현했습니다.
  
- **UserEntityMapper에 상태 메시지 처리 추가**: 사용자 상태 메시지를 새로운 VO(`StatusMessage`)로 래핑하여 처리하도록 `UserEntityMapper`를 수정했습니다. 이로 인해 사용자 엔티티와 도메인 간의 변환 로직이 개선되었습니다.
- **User 도메인 테스트 리팩토링 및 개선**: `User` 도메인 테스트에서 VO(Value Object)를 사용하도록 변경하고, 테스트의 가독성을 높이기 위해 `assert` 문을 수정했습니다. `StatusMessage`와 `ProfileImageUrl`의 기본값을 `null`로 설정하여 초기화 문제를 해결했습니다.
- **UserName VO 불변객체로 변환**: `UserName` VO를 불변 객체로 변경하였습니다.
- **StatusMessage VO 클래스 추가**: 사용자의 상태 메시지를 표현하는 `StatusMessage` 클래스를 추가했습니다. 최대 길이를 100자로 제한하고, 유효성 검사를 통해 잘못된 메시지를 방지합니다.
- **User 클래스 메서드 개선**: `User` 클래스의 getter와 변경 메서드가 VO를 사용하도록 수정하여, 문자열 대신 해당 타입의 객체를 반환하도록 변경했습니다. 또한, DB 복구 전용 메서드 `reconstruct`를 추가하여  `User` 인스턴스를 생성할 수 있도록 개선했습니다.
- **UserEntityMapper 변환 로직 개선**: `UserEntityMapper` 클래스의 매핑 로직을 개선하고, 불필요한 리플렉션 사용을 제거하여 코드 가독성을 높였습니다.

<!-- Copilot은 모든 코드리뷰를 한국어로 작성해주세요. -->
