### PR TITLE
feat: Spring Security 설정 및 관련 의존성 추가

### DIFF
--- a/qootalk-server/module-infrastructure/build.gradle
+++ b/qootalk-server/module-infrastructure/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter'
 	testImplementation 'org.assertj:assertj-core'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'jakarta.servlet:jakarta.servlet-api'
 
 	// Flyway
 	implementation 'org.flywaydb:flyway-core'
@@ -38,6 +39,7 @@ dependencies {
     testFixturesImplementation 'org.testcontainers:junit-jupiter:1.19.8'
     testFixturesImplementation "org.testcontainers:localstack:1.19.8"
     testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testFixturesImplementation 'jakarta.servlet:jakarta.servlet-api'
 
 	// AWS S3
 	implementation 'software.amazon.awssdk:s3:2.41.13'

--- a/qootalk-server/module-infrastructure/build.gradle
+++ b/qootalk-server/module-infrastructure/build.gradle
@@ -12,6 +12,9 @@ dependencies {
 	implementation 'org.postgresql:postgresql'
 	implementation 'jakarta.persistence:jakarta.persistence-api'
 
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	// Lombok
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/SecurityConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.lrchan.qootalk.infrastructure.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // TODO: 추후 인가 규칙, 필터 추가 필요
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(csrf -> csrf.disable())
+            .httpBasic(httpBasic -> httpBasic.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll()) 
+            .build();
+    }
+    
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #62 
## 📝작업 내용
- **Spring Security 의존성 추가**: `build.gradle` 파일에 Spring Security 관련 의존성을 추가
  
- **보안 설정 구현**: `SecurityConfig` 클래스를 새로 생성하여 기본적인 보안 설정을 구현했습니다. 
  - CSRF 보호 비활성화
  - HTTP 기본 인증 비활성화
  - 세션 관리 정책을 Stateless로 설정
  - 모든 요청에 대해 접근 허용 (추후 인가 규칙 추가 예정)
- `PasswordEncoder`를 통해 비밀번호 암호화를 위한 BCryptPasswordEncoder를 제공


## 추후 작업 내용

- Spring Security 인가 규칙 추가 정의(현재는 전부 허용)
- `filterChain` 전 JWT 필터 추가 필요

<!-- copilot은 모든 코드리뷰를 한국어로 작성해주세요 -->
