### PR TITLE
test: Application 레이어 user 관련 service 로직 테스트 추가

### DIFF
--- a/qootalk-server/module-application/build.gradle
+++ b/qootalk-server/module-application/build.gradle
@@ -11,5 +11,10 @@ dependencies {
 
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// Test
+	testImplementation 'org.junit.jupiter:junit-jupiter'
+	testImplementation 'org.assertj:assertj-core'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/dto/command/DeleteProfileImageCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/dto/command/DeleteProfileImageCommand.java
@@ -2,7 +2,7 @@ package com.lrchan.qootalk.application.user.dto.command;
 
 import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
 
-public record DeleateProfileImageCommand(
+public record DeleteProfileImageCommand(
     Long userId,
     ProfileImageUrl profileImageUrl
 ){

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/dto/result/UserQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/dto/result/UserQueryResult.java
@@ -20,7 +20,7 @@ public record UserQueryResult(
             user.id(),
             user.email().value(),
             user.name().value(),
-            user.profileImageUrl() == null ? null : user.profileImageUrl().value(),
+            user.profileImageUrl().value(),
             user.statusMessage().value(),
             user.role().name(),
             user.createdAt(),

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/port/in/DeleteProfileImageUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/port/in/DeleteProfileImageUsecase.java
@@ -1,8 +1,8 @@
 package com.lrchan.qootalk.application.user.port.in;
 
-import com.lrchan.qootalk.application.user.dto.command.DeleateProfileImageCommand;
+import com.lrchan.qootalk.application.user.dto.command.DeleteProfileImageCommand;
 import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
 
 public interface DeleteProfileImageUsecase {
-    UserQueryResult delete(DeleateProfileImageCommand command);
+    UserQueryResult delete(DeleteProfileImageCommand command);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageService.java
@@ -11,6 +11,7 @@ import com.lrchan.qootalk.common.exception.ApplicationException;
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.user.User;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
 
 import lombok.RequiredArgsConstructor;
 
@@ -41,7 +42,7 @@ public class DeleteProfileImageService implements DeleteProfileImageUsecase {
 
         deleteProfileImagePort.delete(command.profileImageUrl().value());
 
-        user.changeProfileImageUrl(null);
+        user.changeProfileImageUrl(new ProfileImageUrl(null));
 
         User updatedUser = saveUserPort.save(user);
 

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageService.java
@@ -11,7 +11,6 @@ import com.lrchan.qootalk.common.exception.ApplicationException;
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.user.User;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
-import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
 
 import lombok.RequiredArgsConstructor;
 

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageService.java
@@ -1,6 +1,6 @@
 package com.lrchan.qootalk.application.user.service;
 
-import com.lrchan.qootalk.application.user.dto.command.DeleateProfileImageCommand;
+import com.lrchan.qootalk.application.user.dto.command.DeleteProfileImageCommand;
 import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
 import com.lrchan.qootalk.application.user.error.UserApplicationErrorCode;
 import com.lrchan.qootalk.application.user.port.in.DeleteProfileImageUsecase;
@@ -28,7 +28,7 @@ public class DeleteProfileImageService implements DeleteProfileImageUsecase {
     private final LoadUserPort loadUserPort;
 
     @Override
-    public UserQueryResult delete(DeleateProfileImageCommand command) {
+    public UserQueryResult delete(DeleteProfileImageCommand command) {
         User user = loadUserPort.findById(command.userId())
             .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
         

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/UploadProfileImageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/UploadProfileImageService.java
@@ -47,8 +47,8 @@ public class UploadProfileImageService implements UploadProfileImageUsecase {
 
         user.changeProfileImageUrl(new ProfileImageUrl(uri));
 
-        saveUserPort.save(user);
+        User updatedUser = saveUserPort.save(user);
 
-        return UserQueryResult.of(user);
+        return UserQueryResult.of(updatedUser);
     }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/UploadProfileImageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/UploadProfileImageService.java
@@ -41,7 +41,7 @@ public class UploadProfileImageService implements UploadProfileImageUsecase {
             command.fileSize());
         String uri = uploadProfileImagePort.upload(command.inputStream(), resource);
                         
-        if (user.profileImageUrl() != null) {
+        if (user.profileImageUrl().value() != null) {
             deleteProfileImagePort.delete(user.profileImageUrl().value());
         }
 

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageServiceTest.java
@@ -1,0 +1,148 @@
+package com.lrchan.qootalk.application.user.service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.user.dto.command.DeleateProfileImageCommand;
+import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+import com.lrchan.qootalk.application.user.error.UserApplicationErrorCode;
+import com.lrchan.qootalk.application.user.port.out.DeleteFilePort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.application.user.port.out.SaveUserPort;
+import com.lrchan.qootalk.common.exception.ApplicationException;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.UserRole;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.Password;
+import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
+import com.lrchan.qootalk.domain.user.vo.StatusMessage;
+import com.lrchan.qootalk.domain.user.vo.UserName;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteProfileImageService 테스트")
+public class DeleteProfileImageServiceTest {
+    
+    @Mock
+    private DeleteFilePort deleteProfileImagePort;
+
+    @Mock
+    private SaveUserPort saveUserPort;
+
+    @Mock
+    private LoadUserPort loadUserPort;
+
+    @InjectMocks
+    private DeleteProfileImageService deleteProfileImageService;
+
+    @Test
+    @DisplayName("프로필 이미지 삭제 성공: 프로필 이미지가 존재하는 경우")
+    public void should_DeleteProfileImage_When_ProfileImageIsDeleted() {
+        // given
+        User user = User.reconstruct(1L, new Email("test@example.com"), new Password("password123"), new UserName("홍길동"), new ProfileImageUrl("https://example.com/profile.jpg"), new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        DeleateProfileImageCommand command = new DeleateProfileImageCommand(
+            1L,
+            new ProfileImageUrl("https://example.com/profile.jpg")
+        );
+
+        given(loadUserPort.findById(command.userId())).willReturn(Optional.of(user));
+        given(saveUserPort.save(any(User.class))).willReturn(user);
+
+        // when
+        UserQueryResult result = deleteProfileImageService.delete(command);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.email()).isEqualTo(user.email().value());
+        assertThat(result.name()).isEqualTo(user.name().value());
+        assertThat(result.profileImageUrl()).isNull();
+
+        verify(loadUserPort, times(1)).findById(command.userId());
+        verify(saveUserPort, times(1)).save(any(User.class));
+        verify(deleteProfileImagePort, times(1)).delete(command.profileImageUrl().value());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제 실패: 프로필 이미지가 존재하지 않는 경우")
+    public void should_FailToDeleteProfileImage_When_ProfileImageIsNotFound() {
+        // given
+        User user = User.reconstruct(1L, new Email("test@example.com"), new Password("password123"), new UserName("홍길동"), new ProfileImageUrl(null), new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        DeleateProfileImageCommand command = new DeleateProfileImageCommand(
+            1L,
+            new ProfileImageUrl(null)
+        );
+
+        given(loadUserPort.findById(command.userId())).willReturn(Optional.of(user));
+
+        // when
+        UserQueryResult result = deleteProfileImageService.delete(command);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.email()).isEqualTo(user.email().value());
+        assertThat(result.name()).isEqualTo(user.name().value());
+        assertThat(result.profileImageUrl()).isNull();
+
+        verify(loadUserPort, times(1)).findById(command.userId());
+        verify(saveUserPort, times(0)).save(any(User.class));
+        verify(deleteProfileImagePort, times(0)).delete(command.profileImageUrl().value());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제 실패: 사용자가 존재하지 않는 경우")
+    public void should_FailToDeleteProfileImage_When_UserNotFound() {
+        // given
+        DeleateProfileImageCommand command = new DeleateProfileImageCommand(
+            1L,
+            new ProfileImageUrl("https://example.com/profile.jpg")
+        );
+
+        given(loadUserPort.findById(command.userId())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> deleteProfileImageService.delete(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+
+        verify(loadUserPort, times(1)).findById(command.userId());
+        verify(saveUserPort, times(0)).save(any(User.class));
+        verify(deleteProfileImagePort, times(0)).delete(command.profileImageUrl().value());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제 실패: 프로필 이미지 URL이 일치하지 않는 경우")
+    public void should_FailToDeleteProfileImage_When_ProfileImageUrlIsNotMatched() {
+        // given
+        User user = User.reconstruct(1L, new Email("test@example.com"), new Password("password123"), new UserName("홍길동"), new ProfileImageUrl("https://example.com/profile.jpg"), new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        DeleateProfileImageCommand command = new DeleateProfileImageCommand(
+            1L,
+            new ProfileImageUrl("https://example.com/wrong.jpg")
+        );
+
+        given(loadUserPort.findById(command.userId())).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> deleteProfileImageService.delete(command))
+            .isInstanceOf(ApplicationException.class)
+            .hasMessage(UserApplicationErrorCode.USER_PROFILE_IMAGE_URL_MISMATCH.getMessage());
+
+        verify(loadUserPort, times(1)).findById(command.userId());
+        verify(saveUserPort, times(0)).save(any(User.class));
+        verify(deleteProfileImagePort, times(0)).delete(command.profileImageUrl().value());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageServiceTest.java
@@ -17,7 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.lrchan.qootalk.application.user.dto.command.DeleateProfileImageCommand;
+import com.lrchan.qootalk.application.user.dto.command.DeleteProfileImageCommand;
 import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
 import com.lrchan.qootalk.application.user.error.UserApplicationErrorCode;
 import com.lrchan.qootalk.application.user.port.out.DeleteFilePort;
@@ -55,7 +55,7 @@ public class DeleteProfileImageServiceTest {
     public void should_DeleteProfileImage_When_ProfileImageIsDeleted() {
         // given
         User user = User.reconstruct(1L, new Email("test@example.com"), new Password("password123"), new UserName("홍길동"), new ProfileImageUrl("https://example.com/profile.jpg"), new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
-        DeleateProfileImageCommand command = new DeleateProfileImageCommand(
+        DeleteProfileImageCommand command = new DeleteProfileImageCommand(
             1L,
             new ProfileImageUrl("https://example.com/profile.jpg")
         );
@@ -82,7 +82,7 @@ public class DeleteProfileImageServiceTest {
     public void should_FailToDeleteProfileImage_When_ProfileImageIsNotFound() {
         // given
         User user = User.reconstruct(1L, new Email("test@example.com"), new Password("password123"), new UserName("홍길동"), new ProfileImageUrl(null), new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
-        DeleateProfileImageCommand command = new DeleateProfileImageCommand(
+        DeleteProfileImageCommand command = new DeleteProfileImageCommand(
             1L,
             new ProfileImageUrl(null)
         );
@@ -107,7 +107,7 @@ public class DeleteProfileImageServiceTest {
     @DisplayName("프로필 이미지 삭제 실패: 사용자가 존재하지 않는 경우")
     public void should_FailToDeleteProfileImage_When_UserNotFound() {
         // given
-        DeleateProfileImageCommand command = new DeleateProfileImageCommand(
+        DeleteProfileImageCommand command = new DeleteProfileImageCommand(
             1L,
             new ProfileImageUrl("https://example.com/profile.jpg")
         );
@@ -129,7 +129,7 @@ public class DeleteProfileImageServiceTest {
     public void should_FailToDeleteProfileImage_When_ProfileImageUrlIsNotMatched() {
         // given
         User user = User.reconstruct(1L, new Email("test@example.com"), new Password("password123"), new UserName("홍길동"), new ProfileImageUrl("https://example.com/profile.jpg"), new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
-        DeleateProfileImageCommand command = new DeleateProfileImageCommand(
+        DeleteProfileImageCommand command = new DeleteProfileImageCommand(
             1L,
             new ProfileImageUrl("https://example.com/wrong.jpg")
         );

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/RegisterUserServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/RegisterUserServiceTest.java
@@ -105,6 +105,7 @@ public class RegisterUserServiceTest {
         
         given(loadUserPort.findByEmail(command.email().value())).willReturn(Optional.empty());
         given(passwordEncoder.encode(command.password().encryptedPassword())).willReturn("encodedPassword");
+        given(saveUserPort.save(any(User.class))).willReturn(User.create(command.email(), new Password("encodedPassword"), command.name()));
         
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
 

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/RegisterUserServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/RegisterUserServiceTest.java
@@ -1,0 +1,94 @@
+package com.lrchan.qootalk.application.user.service;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.user.port.out.SaveUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.Password;
+import com.lrchan.qootalk.domain.user.vo.UserName;
+import com.lrchan.qootalk.application.user.dto.command.RegisterUserCommand;
+import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RegisterUserService 테스트")
+public class RegisterUserServiceTest {
+
+    @Mock
+    private SaveUserPort saveUserPort;
+
+    @Mock
+    private LoadUserPort loadUserPort;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private RegisterUserService registerUserService;
+
+    @Test
+    @DisplayName("회원가입 성공: 이메일이 중복되지 않는 경우")
+    public void should_RegisterUser_When_EmailIsNotDuplicated() {
+        // given
+        RegisterUserCommand command = new RegisterUserCommand(
+            new Email("test@example.com"),
+            new Password("password123"),
+            new UserName("홍길동")
+        );
+        
+        given(loadUserPort.findByEmail(command.email().value())).willReturn(Optional.empty());
+        given(passwordEncoder.encode(command.password().encryptedPassword())).willReturn("encodedPassword");
+        given(saveUserPort.save(any(User.class))).willReturn(User.create(command.email(), command.password(), command.name()));
+
+        // when
+        UserQueryResult result = registerUserService.register(command);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.email()).isEqualTo(command.email().value());
+        assertThat(result.name()).isEqualTo(command.name().value());
+        
+        verify(loadUserPort, times(1)).findByEmail(command.email().value());
+        verify(passwordEncoder, times(1)).encode(command.password().encryptedPassword());
+        verify(saveUserPort, times(1)).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패: 이메일이 중복된 경우")
+    public void should_FailToRegisterUser_When_EmailIsDuplicated() {
+        // given
+        RegisterUserCommand command = new RegisterUserCommand(
+            new Email("test@example.com"),
+            new Password("password123"),
+            new UserName("홍길동")
+        );
+
+        given(loadUserPort.findByEmail(command.email().value())).willReturn(Optional.of(User.create(command.email(), command.password(), command.name())));
+
+        // when & then
+        assertThatThrownBy(() -> registerUserService.register(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(UserErrorCode.USER_ALREADY_EXISTS.getMessage());
+
+        verify(loadUserPort, times(1)).findByEmail(command.email().value());
+        verify(passwordEncoder, times(0)).encode(command.password().encryptedPassword());
+        verify(saveUserPort, times(0)).save(any(User.class));
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/RegisterUserServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/RegisterUserServiceTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -90,5 +91,28 @@ public class RegisterUserServiceTest {
         verify(loadUserPort, times(1)).findByEmail(command.email().value());
         verify(passwordEncoder, times(0)).encode(command.password().encryptedPassword());
         verify(saveUserPort, times(0)).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호가 인코딩되어 저장된다")
+    public void should_PasswordBeEncodedAndSaved() {
+        // given
+        RegisterUserCommand command = new RegisterUserCommand(
+            new Email("test@example.com"),
+            new Password("password123"),
+            new UserName("홍길동")
+        );
+        
+        given(loadUserPort.findByEmail(command.email().value())).willReturn(Optional.empty());
+        given(passwordEncoder.encode(command.password().encryptedPassword())).willReturn("encodedPassword");
+        
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+
+        // when
+        registerUserService.register(command);
+
+        // then
+        verify(saveUserPort, times(1)).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().password().encryptedPassword()).isEqualTo("encodedPassword");
     }
 }

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/UpdateStatusMessageServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/UpdateStatusMessageServiceTest.java
@@ -1,0 +1,90 @@
+package com.lrchan.qootalk.application.user.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.user.dto.command.UpdateStatusMessageCommand;
+import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.application.user.port.out.SaveUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.UserRole;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.Password;
+import com.lrchan.qootalk.domain.user.vo.StatusMessage;
+import com.lrchan.qootalk.domain.user.vo.UserName;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateStatusMessageService 테스트")
+public class UpdateStatusMessageServiceTest {
+    @Mock
+    private LoadUserPort loadUserPort;
+
+    @Mock
+    private SaveUserPort saveUserPort;
+
+    @InjectMocks
+    private UpdateStatusMessageService updateStatusMessageService;
+
+    @Test
+    @DisplayName("상태 메시지 업데이트 성공")
+    public void should_UpdateStatusMessage_When_StatusMessageIsUpdated() {
+        // given
+        User user = User.reconstruct(1L, new Email("test@example.com"), new Password("password123"), new UserName("홍길동"), null, new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        UpdateStatusMessageCommand command = new UpdateStatusMessageCommand(
+            1L,
+            "안녕하세요!"
+        );
+
+        given(loadUserPort.findById(command.userId())).willReturn(Optional.of(user));
+        given(saveUserPort.save(any(User.class))).willReturn(user);
+
+        // when
+        UserQueryResult result = updateStatusMessageService.update(command);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.email()).isEqualTo(user.email().value());
+        assertThat(result.name()).isEqualTo(user.name().value());
+        assertThat(result.statusMessage()).isEqualTo(command.statusMessage());
+
+        verify(loadUserPort, times(1)).findById(command.userId());
+        verify(saveUserPort, times(1)).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("상태 메시지 업데이트 실패: 사용자가 존재하지 않는 경우")
+    public void should_FailToUpdateStatusMessage_When_UserNotFound() {
+        // given
+        UpdateStatusMessageCommand command = new UpdateStatusMessageCommand(
+            1L,
+            "안녕하세요!"
+        );
+
+        given(loadUserPort.findById(command.userId())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> updateStatusMessageService.update(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+
+        verify(loadUserPort, times(1)).findById(command.userId());
+        verify(saveUserPort, times(0)).save(any(User.class));
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/UploadProfileImageServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/user/service/UploadProfileImageServiceTest.java
@@ -1,0 +1,192 @@
+package com.lrchan.qootalk.application.user.service;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.user.dto.command.UploadProfileImageCommand;
+import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+import com.lrchan.qootalk.application.user.port.out.DeleteFilePort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.application.user.port.out.SaveUserPort;
+import com.lrchan.qootalk.application.user.port.out.UploadFilePort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.common.storage.vo.StorageResource;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.UserRole;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.Password;
+import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
+import com.lrchan.qootalk.domain.user.vo.StatusMessage;
+import com.lrchan.qootalk.domain.user.vo.UserName;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UploadProfileImageService 테스트")
+public class UploadProfileImageServiceTest {
+
+    @Mock
+    private UploadFilePort uploadProfileImagePort;
+    
+    @Mock
+    private DeleteFilePort deleteProfileImagePort;
+
+    @Mock
+    private LoadUserPort loadUserPort;
+
+    @Mock
+    private SaveUserPort saveUserPort;
+
+    @InjectMocks
+    private UploadProfileImageService uploadProfileImageService;
+
+    @Test
+    @DisplayName("프로필 이미지 업로드 성공 : 업로드 전 프로필 이미지가 존재하지 않는 경우")
+    public void should_UploadProfileImage_When_ProfileImageIsUploaded_And_PreviousProfileImageIsNotFound() {
+        // given
+        User user = User.reconstruct(1L, new Email("test@example.com"), new Password("password123"), new UserName("홍길동"), new ProfileImageUrl(null), new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        UploadProfileImageCommand command = new UploadProfileImageCommand(
+            1L,
+            new ByteArrayInputStream("profile.jpg".getBytes()),
+            "test.jpg",
+            "image/jpeg",
+            (long) "profile.jpg".getBytes().length
+        );
+        StorageResource storageResource = new StorageResource(
+            "profile/" + command.userId(), 
+            "test.jpg", 
+            "image/jpeg", 
+            (long) "profile.jpg".getBytes().length
+        );
+    
+        given(loadUserPort.findById(command.userId())).willReturn(Optional.of(user));
+        given(saveUserPort.save(any(User.class))).willReturn(user);
+        given(uploadProfileImagePort.upload(command.inputStream(), storageResource)).willReturn("https://example.com/profile.jpg");
+
+        // when
+        UserQueryResult result = uploadProfileImageService.upload(command);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.email()).isEqualTo(user.email().value());
+        assertThat(result.name()).isEqualTo(user.name().value());
+        assertThat(result.profileImageUrl()).isEqualTo("https://example.com/profile.jpg");
+    
+        verify(loadUserPort, times(1)).findById(command.userId());
+        verify(saveUserPort, times(1)).save(any(User.class));
+        verify(uploadProfileImagePort, times(1)).upload(command.inputStream(), storageResource);
+        verify(deleteProfileImagePort, times(0)).delete(any(String.class));
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드 성공 : 업로드 전 프로필 이미지가 존재하는 경우")
+    public void should_UploadProfileImage_When_ProfileImageIsUploaded_And_PreviousProfileImageIsFound() {
+        // given
+        User user = User.reconstruct(1L, new Email("test@example.com"), new Password("password123"), new UserName("홍길동"), new ProfileImageUrl("https://example.com/profile.jpg"), new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        UploadProfileImageCommand command = new UploadProfileImageCommand(
+            1L,
+            new ByteArrayInputStream("profile.jpg".getBytes()),
+            "test.jpg",
+            "image/jpeg",
+            (long) "profile.jpg".getBytes().length
+        );
+        StorageResource storageResource = new StorageResource(
+            "profile/" + command.userId(), 
+            "test.jpg", 
+            "image/jpeg", 
+            (long) "profile.jpg".getBytes().length
+        );
+    
+        given(loadUserPort.findById(command.userId())).willReturn(Optional.of(user));
+        given(saveUserPort.save(any(User.class))).willReturn(user);
+        given(uploadProfileImagePort.upload(command.inputStream(), storageResource)).willReturn("https://example.com/profile.jpg");
+
+        // when
+        UserQueryResult result = uploadProfileImageService.upload(command);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.email()).isEqualTo(user.email().value());
+        assertThat(result.name()).isEqualTo(user.name().value());
+        assertThat(result.profileImageUrl()).isEqualTo("https://example.com/profile.jpg");
+    
+        verify(loadUserPort, times(1)).findById(command.userId());
+        verify(saveUserPort, times(1)).save(any(User.class));
+        verify(uploadProfileImagePort, times(1)).upload(command.inputStream(), storageResource);
+        verify(deleteProfileImagePort, times(1)).delete("https://example.com/profile.jpg");
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드 실패 : 사용자가 존재하지 않는 경우")
+    public void should_FailToUploadProfileImage_When_UserNotFound() {
+        // given
+        UploadProfileImageCommand command = new UploadProfileImageCommand(
+            1L,
+            new ByteArrayInputStream("profile.jpg".getBytes()),
+            "test.jpg",
+            "image/jpeg",
+            (long) "profile.jpg".getBytes().length
+        );
+
+        given(loadUserPort.findById(command.userId())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> uploadProfileImageService.upload(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+
+        verify(loadUserPort, times(1)).findById(command.userId());
+        verify(saveUserPort, times(0)).save(any(User.class));
+        verify(uploadProfileImagePort, times(0)).upload(any(InputStream.class), any(StorageResource.class));
+        verify(deleteProfileImagePort, times(0)).delete(any(String.class));
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드 실패 : 파일 저장소에 프로필 이미지 업로드 실패")
+    public void should_FailToUploadProfileImage_When_UploadProfileImageFailed() {
+        // given
+        User user = User.reconstruct(1L, new Email("test@example.com"), new Password("password123"), new UserName("홍길동"), new ProfileImageUrl(null), new StatusMessage(""), UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        UploadProfileImageCommand command = new UploadProfileImageCommand(
+            1L,
+            new ByteArrayInputStream("profile.jpg".getBytes()),
+            "test.jpg",
+            "image/jpeg",
+            (long) "profile.jpg".getBytes().length 
+        );
+        StorageResource storageResource = new StorageResource(
+            "profile/" + command.userId(), 
+            "test.jpg", 
+            "image/jpeg", 
+            (long) "profile.jpg".getBytes().length
+        );
+    
+        given(loadUserPort.findById(command.userId())).willReturn(Optional.of(user));
+        given(uploadProfileImagePort.upload(command.inputStream(), storageResource)).willThrow(new RuntimeException("Upload failed"));
+
+        // when & then
+        assertThatThrownBy(() -> uploadProfileImageService.upload(command))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Upload failed");
+
+        verify(loadUserPort, times(1)).findById(command.userId());
+        verify(saveUserPort, times(0)).save(any(User.class));
+        verify(uploadProfileImagePort, times(1)).upload(any(InputStream.class), any(StorageResource.class));
+        verify(deleteProfileImagePort, times(0)).delete(any(String.class));
+    }
+}

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
@@ -78,7 +78,7 @@ public class User extends BaseModel {
     }
 
     public void changeProfileImageUrl(ProfileImageUrl profileImageUrl) {
-        this.profileImageUrl = profileImageUrl;
+        this.profileImageUrl = (profileImageUrl == null) ? new ProfileImageUrl(null) : profileImageUrl;
         update();
     }
 

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/User.java
@@ -34,13 +34,13 @@ public class User extends BaseModel {
         this.email = email;
         this.password = password;
         this.name = name;
-        this.profileImageUrl = profileImageUrl;
+        this.profileImageUrl = (profileImageUrl == null) ? new ProfileImageUrl(null) : profileImageUrl;
         this.statusMessage = (statusMessage == null) ? new StatusMessage("") : statusMessage;
         this.role = role == null ? UserRole.USER : role;
     }
 
     public static User create(Email email, Password password, UserName name) {
-        return new User(null, email, password, name, null, null, UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
+        return new User(null, email, password, name, new ProfileImageUrl(null), null, UserRole.USER, LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     // DB 복구 전용 메서드

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/ProfileImageUrl.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/vo/ProfileImageUrl.java
@@ -19,10 +19,10 @@ public final class ProfileImageUrl {
     }
 
     private void validate(String value) {
-        if (value == null || value.isBlank()) {
-            throw new DomainException(UserErrorCode.USER_INVALID_PROFILE_IMAGE_URL);
+        if (value == null) {
+            return;
         }
-        if (!value.matches("^https?://.*")) {
+        if (value.isBlank() || !value.matches("^https?://.*")) {
             throw new DomainException(UserErrorCode.USER_INVALID_PROFILE_IMAGE_URL);
         }
     }

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/UserTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/UserTest.java
@@ -35,7 +35,7 @@ class UserTest {
             assertThat(user.name().value()).isEqualTo("홍길동");
             assertThat(user.role()).isEqualTo(UserRole.USER);
             assertThat(user.statusMessage()).isEqualTo(new StatusMessage(""));
-            assertThat(user.profileImageUrl()).isNull();
+            assertThat(user.profileImageUrl().value()).isNull();
             assertThat(user.id()).isNull();
             assertThat(user.isDeleted()).isFalse();
         }

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/vo/ProfileImageUrlTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/user/vo/ProfileImageUrlTest.java
@@ -54,20 +54,21 @@ class ProfileImageUrlTest {
             assertThat(new ProfileImageUrl("https://example.com:8080/image.gif").value())
                 .isEqualTo("https://example.com:8080/image.gif");
         }
+
+        @Test
+        @DisplayName("null 값으로 생성할 수 있다")
+        void should_CreateProfileImageUrl_When_Null() {
+            // when
+            ProfileImageUrl profileImageUrl = new ProfileImageUrl(null);
+
+            // then
+            assertThat(profileImageUrl.value()).isNull();
+        }
     }
 
     @Nested
     @DisplayName("검증 실패")
     class ValidationFailureTest {
-
-        @Test
-        @DisplayName("null 값으로 생성하면 예외가 발생한다")
-        void should_ThrowException_When_Null() {
-            // when & then
-            assertThatThrownBy(() -> new ProfileImageUrl(null))
-                .isInstanceOf(DomainException.class)
-                .hasMessage(UserErrorCode.USER_INVALID_PROFILE_IMAGE_URL.getMessage());
-        }
 
         @Test
         @DisplayName("빈 문자열로 생성하면 예외가 발생한다")

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapper.java
@@ -18,7 +18,7 @@ public final class UserEntityMapper {
             new Email(userEntity.getEmail()),
             new Password(userEntity.getPassword()),
             new UserName(userEntity.getName()),
-            userEntity.getProfileImageUrl() != null ? new ProfileImageUrl(userEntity.getProfileImageUrl()) : null,
+            new ProfileImageUrl(userEntity.getProfileImageUrl()),
             new StatusMessage(userEntity.getStatusMessage()),
             userEntity.getRole(),
             userEntity.getCreatedAt(),
@@ -33,7 +33,7 @@ public final class UserEntityMapper {
             .email(user.email().value())
             .password(user.password().encryptedPassword())
             .name(user.name().value())
-            .profileImageUrl(user.profileImageUrl() != null ? user.profileImageUrl().value() : null)
+            .profileImageUrl(user.profileImageUrl().value())
             .statusMessage(user.statusMessage().value())
             .role(user.role())
             .createdAt(user.createdAt())

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapperTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntityMapperTest.java
@@ -79,7 +79,7 @@ class UserEntityMapperTest {
             User user = UserEntityMapper.toDomain(userEntity);
 
             // then
-            assertThat(user.profileImageUrl()).isNull();
+            assertThat(user.profileImageUrl().value()).isNull();
             assertThat(user.statusMessage().value()).isEqualTo("안녕하세요!");
         }
 
@@ -185,7 +185,7 @@ class UserEntityMapperTest {
                 new Email("test@example.com"),
                 new Password("encrypted_password"),
                 new UserName("홍길동"),
-                null,
+                new ProfileImageUrl(null),
                 new StatusMessage("안녕하세요!"),
                 UserRole.USER,
                 now,
@@ -304,7 +304,7 @@ class UserEntityMapperTest {
                 new Email("test@example.com"),
                 new Password("encrypted_password"),
                 new UserName("홍길동"),
-                null,
+                new ProfileImageUrl(null),
                 null,
                 UserRole.USER,
                 now,
@@ -317,7 +317,7 @@ class UserEntityMapperTest {
             User convertedUser = UserEntityMapper.toDomain(userEntity);
 
             // then
-            assertThat(convertedUser.profileImageUrl()).isNull();
+            assertThat(convertedUser.profileImageUrl().value()).isNull();
             assertThat(convertedUser.statusMessage().value()).isEqualTo("");
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #61
## 📝작업 내용
[회원가입 테스트 추가]
- 회원가입 성공: 이메일이 중복되지 않는 경우
- 회원가입 실패: 이메일이 중복된 경우
- verify를 통해 port가 유의미하게 호출되었나 판별

[user status update 테스트 추가]
- 상태 메시지 업데이트 성공
- 상태 메시지 업데이트 실패: 사용자가 존재하지 않는 경우

[user 프로필사진 삭제 테스트 추가]
- 프로필 이미지 삭제 성공: 프로필 이미지가 존재하는 경우
- 프로필 이미지 삭제 실패: 프로필 이미지가 존재하지 않는 경우
- 프로필 이미지 삭제 실패: 사용자가 존재하지 않는 경우
- 프로필 이미지 삭제 실패: 프로필 이미지 URL이 일치하지 않는 경우

[user 프로필사진 업로드 테스트 추가]
- 프로필 이미지 업로드 성공 : 업로드 전 프로필 이미지가 존재하지 않는 경우
- 프로필 이미지 업로드 성공 : 업로드 전 프로필 이미지가 존재하는 경우
- 프로필 이미지 업로드 실패 : 사용자가 존재하지 않는 경우
- 프로필 이미지 업로드 실패 : 파일 저장소에 프로필 이미지 업로드 실패"

## 기타 수정사항

- 기존 UserProfileUrl null 체크 방식 변경
  - 안정성 및 코드 일관성을 이유로 객체를 null하는 방식에서 객체값을 null하는 방식으로 변경

<!-- copilot 은 모든 코드리뷰를 한국어로 작성해주세요 -->
