### PR TITLE
feat: JWT 예외 처리 필터 추가

### DIFF
--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/error/UserApplicationErrorCode.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/error/UserApplicationErrorCode.java
@@ -3,15 +3,17 @@ package com.lrchan.qootalk.application.user.error;
 import com.lrchan.qootalk.common.error.ErrorCode;
 
 public enum UserApplicationErrorCode implements ErrorCode {
-    LOGIN_FAILED("USER_001", "로그인에 실패했습니다."),
-    USER_PROFILE_IMAGE_URL_MISMATCH("USER_002", "프로필 이미지 URL이 일치하지 않습니다.");
+    LOGIN_FAILED("USER_001", "로그인에 실패했습니다.", 401),
+    USER_PROFILE_IMAGE_URL_MISMATCH("USER_002", "프로필 이미지 URL이 일치하지 않습니다.", 400);
 
     private final String code;
     private final String message;
+    private final int httpStatus;
 
-    UserApplicationErrorCode(String code, String message) {
+    UserApplicationErrorCode(String code, String message, int httpStatus) {
         this.code = code;
         this.message = message;
+        this.httpStatus = httpStatus;
     }
 
     @Override
@@ -22,5 +24,10 @@ public enum UserApplicationErrorCode implements ErrorCode {
     @Override
     public String getMessage() {
         return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
     }
 }

--- a/qootalk-server/module-common/src/main/java/com/lrchan/qootalk/common/error/ErrorCode.java
+++ b/qootalk-server/module-common/src/main/java/com/lrchan/qootalk/common/error/ErrorCode.java
@@ -3,4 +3,5 @@ package com.lrchan.qootalk.common.error;
 public interface ErrorCode {
     String getCode();
     String getMessage();
+    int getHttpStatus();
 }

--- a/qootalk-server/module-common/src/main/java/com/lrchan/qootalk/common/error/GlobalErrorCode.java
+++ b/qootalk-server/module-common/src/main/java/com/lrchan/qootalk/common/error/GlobalErrorCode.java
@@ -2,17 +2,19 @@ package com.lrchan.qootalk.common.error;
 
 public enum GlobalErrorCode implements ErrorCode {
 
-    INTERNAL_ERROR("GLOBAL_001", "서버 내부 오류가 발생했습니다."),
-    INVALID_INPUT("GLOBAL_002", "잘못된 요청입니다."),
-    UNAUTHORIZED("GLOBAL_003", "인증되지 않은 요청입니다."),
-    FORBIDDEN("GLOBAL_004", "권한이 없습니다.");
+    INTERNAL_ERROR("GLOBAL_001", "서버 내부 오류가 발생했습니다.", 500),
+    INVALID_INPUT("GLOBAL_002", "잘못된 요청입니다.", 400),
+    UNAUTHORIZED("GLOBAL_003", "인증되지 않은 요청입니다.", 401),
+    FORBIDDEN("GLOBAL_004", "권한이 없습니다.", 403);
 
     private final String code;
     private final String message;
+    private final int httpStatus;
 
-    GlobalErrorCode(String code, String message) {
+    GlobalErrorCode(String code, String message, int httpStatus) {
         this.code = code;
         this.message = message;
+        this.httpStatus = httpStatus;
     }
 
     @Override
@@ -23,5 +25,10 @@ public enum GlobalErrorCode implements ErrorCode {
     @Override
     public String getMessage() {
         return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
     }
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
@@ -4,26 +4,28 @@ import com.lrchan.qootalk.common.error.ErrorCode;
 
 public enum ChatErrorCode implements ErrorCode {
     
-    CHAT_ROOM_NOT_FOUND("CHAT_001", "채팅방을 찾을 수 없습니다."),
-    CHAT_ROOM_ALREADY_EXISTS("CHAT_002", "이미 존재하는 채팅방입니다."),
-    CHAT_ROOM_INVALID_NAME("CHAT_003", "채팅방 이름이 올바르지 않습니다."),
-    CHAT_ROOM_INVALID_TYPE("CHAT_004", "채팅방 타입이 올바르지 않습니다."),
-    CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID("CHAT_005", "마지막 읽은 메시지 ID가 올바르지 않습니다."),
+    CHAT_ROOM_NOT_FOUND("CHAT_001", "채팅방을 찾을 수 없습니다.", 404),
+    CHAT_ROOM_ALREADY_EXISTS("CHAT_002", "이미 존재하는 채팅방입니다.", 400),
+    CHAT_ROOM_INVALID_NAME("CHAT_003", "채팅방 이름이 올바르지 않습니다.", 400),
+    CHAT_ROOM_INVALID_TYPE("CHAT_004", "채팅방 타입이 올바르지 않습니다.", 400),
+    CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID("CHAT_005", "마지막 읽은 메시지 ID가 올바르지 않습니다.", 400),
 
-    CHAT_FILE_METADATA_INVALID_STORAGE_TYPE("CHAT_006", "파일 메타데이터 스토리지 타입이 올바르지 않습니다."),
-    CHAT_FILE_METADATA_INVALID_FILE_NAME("CHAT_007", "파일 이름이 올바르지 않습니다."),
-    CHAT_FILE_METADATA_INVALID_CONTENT_TYPE("CHAT_008", "파일 메타데이터 콘텐츠 타입이 올바르지 않습니다."),
-    CHAT_FILE_METADATA_INVALID_FILE_SIZE("CHAT_009", "파일 크기가 올바르지 않습니다."),
-    CHAT_FILE_SECURITY_INVALID_MALICIOUS_FILE_DOWNLOADABLE_OR_SHAREABLE("CHAT_010", "악성 파일은 다운로드 및 공유가 불가능합니다."),
-    CHAT_FILE_SECURITY_INVALID_PUBLIC_FILE_DOWNLOADABLE("CHAT_011", "공개 파일의 다운로드를 비활성화할 수 없습니다."),
-    CHAT_FILE_METADATA_INVALID_PATH("CHAT_012", "파일 경로가 올바르지 않습니다.");
+    CHAT_FILE_METADATA_INVALID_STORAGE_TYPE("CHAT_006", "파일 메타데이터 스토리지 타입이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_FILE_NAME("CHAT_007", "파일 이름이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_CONTENT_TYPE("CHAT_008", "파일 메타데이터 콘텐츠 타입이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_FILE_SIZE("CHAT_009", "파일 크기가 올바르지 않습니다.", 400),
+    CHAT_FILE_SECURITY_INVALID_MALICIOUS_FILE_DOWNLOADABLE_OR_SHAREABLE("CHAT_010", "악성 파일은 다운로드 및 공유가 불가능합니다.", 400),
+    CHAT_FILE_SECURITY_INVALID_PUBLIC_FILE_DOWNLOADABLE("CHAT_011", "공개 파일의 다운로드를 비활성화할 수 없습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_PATH("CHAT_012", "파일 경로가 올바르지 않습니다.", 400);
 
     private final String code;
     private final String message;
+    private final int httpStatus;
 
-    ChatErrorCode(String code, String message) {
+    ChatErrorCode(String code, String message, int httpStatus) {
         this.code = code;
         this.message = message;
+        this.httpStatus = httpStatus;
     }
     
     @Override
@@ -34,5 +36,10 @@ public enum ChatErrorCode implements ErrorCode {
     @Override
     public String getMessage() {
         return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
     }
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/error/UserErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/user/error/UserErrorCode.java
@@ -3,24 +3,26 @@ package com.lrchan.qootalk.domain.user.error;
 import com.lrchan.qootalk.common.error.ErrorCode;
 
 public enum UserErrorCode implements ErrorCode {
-    USER_NOT_FOUND("USER_001", "사용자를 찾을 수 없습니다."),
-    USER_ALREADY_EXISTS("USER_002", "이미 존재하는 사용자입니다."),
-    USER_INVALID_PASSWORD("USER_003", "비밀번호가 올바르지 않습니다."),
-    USER_INVALID_EMAIL("USER_004", "이메일 형식이 올바르지 않습니다."),
-    USER_INVALID_NAME("USER_005", "이름 형식이 올바르지 않습니다."),
-    USER_INVALID_PROFILE_IMAGE_URL("USER_006", "프로필 이미지 URL 형식이 올바르지 않습니다."),
-    USER_INVALID_STATUS_MESSAGE("USER_007", "상태 메시지 형식이 올바르지 않습니다."),
-    USER_INVALID_ROLE("USER_008", "역할 형식이 올바르지 않습니다."),
-    USER_DELETED("USER_009", "삭제된 사용자입니다."),
-    USER_INVALID_ISSUED_TOKEN("USER_010", "발급된 토큰이 올바르지 않습니다."),
-    USER_INVALID_EXPIRED_TOKEN("USER_011", "만료된 토큰입니다.");
+    USER_NOT_FOUND("USER_001", "사용자를 찾을 수 없습니다.", 404),
+    USER_ALREADY_EXISTS("USER_002", "이미 존재하는 사용자입니다.", 400),
+    USER_INVALID_PASSWORD("USER_003", "비밀번호가 올바르지 않습니다.", 400),
+    USER_INVALID_EMAIL("USER_004", "이메일 형식이 올바르지 않습니다.", 400),
+    USER_INVALID_NAME("USER_005", "이름 형식이 올바르지 않습니다.", 400),
+    USER_INVALID_PROFILE_IMAGE_URL("USER_006", "프로필 이미지 URL 형식이 올바르지 않습니다.", 400),
+    USER_INVALID_STATUS_MESSAGE("USER_007", "상태 메시지 형식이 올바르지 않습니다.", 400),
+    USER_INVALID_ROLE("USER_008", "역할 형식이 올바르지 않습니다.", 400),
+    USER_DELETED("USER_009", "삭제된 사용자입니다.", 400),
+    USER_INVALID_ISSUED_TOKEN("USER_010", "발급된 토큰이 올바르지 않습니다.", 400),
+    USER_INVALID_EXPIRED_TOKEN("USER_011", "만료된 토큰입니다.", 400);
 
     private final String code;
     private final String message;
+    private final int httpStatus;
 
-    UserErrorCode(String code, String message) {
+    UserErrorCode(String code, String message, int httpStatus) {
         this.code = code;
         this.message = message;
+        this.httpStatus = httpStatus;
     }
 
     @Override
@@ -31,5 +33,10 @@ public enum UserErrorCode implements ErrorCode {
     @Override
     public String getMessage() {
         return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/common/error/AuthErrorCode.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/common/error/AuthErrorCode.java
@@ -4,18 +4,20 @@ import com.lrchan.qootalk.common.error.ErrorCode;
 
 public enum AuthErrorCode implements ErrorCode {
     
-    INVALID_JWT_SIGNATURE("AUTH_001", "잘못된 JWT 서명입니다."),
-    INVALID_JWT_EXPIRED("AUTH_002", "만료된 JWT 토큰입니다."),
-    INVALID_JWT_UNSUPPORTED("AUTH_003", "지원되지 않는 JWT 토큰입니다."),
-    INVALID_JWT_ILLEGAL_ARGUMENT("AUTH_004", "잘못된 JWT 토큰입니다."),
-    INVALID_JWT_MALFORMED("AUTH_005", "잘못된 JWT 형식입니다.");
+    INVALID_JWT_SIGNATURE("AUTH_001", "잘못된 JWT 서명입니다.", 401),
+    INVALID_JWT_EXPIRED("AUTH_002", "만료된 JWT 토큰입니다.", 401),
+    INVALID_JWT_UNSUPPORTED("AUTH_003", "지원되지 않는 JWT 토큰입니다.", 401),
+    INVALID_JWT_ILLEGAL_ARGUMENT("AUTH_004", "잘못된 JWT 토큰입니다.", 401),
+    INVALID_JWT_MALFORMED("AUTH_005", "잘못된 JWT 형식입니다.", 401);
 
     private final String code;
     private final String message;
+    private final int httpStatus;
 
-    AuthErrorCode(String code, String message) {
+    AuthErrorCode(String code, String message, int httpStatus) {
         this.code = code;
         this.message = message;
+        this.httpStatus = httpStatus;
     }
 
     @Override
@@ -26,5 +28,10 @@ public enum AuthErrorCode implements ErrorCode {
     @Override
     public String getMessage() {
         return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/common/error/AuthErrorCode.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/common/error/AuthErrorCode.java
@@ -7,7 +7,8 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_JWT_SIGNATURE("AUTH_001", "잘못된 JWT 서명입니다."),
     INVALID_JWT_EXPIRED("AUTH_002", "만료된 JWT 토큰입니다."),
     INVALID_JWT_UNSUPPORTED("AUTH_003", "지원되지 않는 JWT 토큰입니다."),
-    INVALID_JWT_ILLEGAL_ARGUMENT("AUTH_004", "잘못된 JWT 토큰입니다.");
+    INVALID_JWT_ILLEGAL_ARGUMENT("AUTH_004", "잘못된 JWT 토큰입니다."),
+    INVALID_JWT_MALFORMED("AUTH_005", "잘못된 JWT 형식입니다.");
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/common/error/AuthErrorCode.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/common/error/AuthErrorCode.java
@@ -1,0 +1,29 @@
+package com.lrchan.qootalk.infrastructure.common.error;
+
+import com.lrchan.qootalk.common.error.ErrorCode;
+
+public enum AuthErrorCode implements ErrorCode {
+    
+    INVALID_JWT_SIGNATURE("AUTH_001", "잘못된 JWT 서명입니다."),
+    INVALID_JWT_EXPIRED("AUTH_002", "만료된 JWT 토큰입니다."),
+    INVALID_JWT_UNSUPPORTED("AUTH_003", "지원되지 않는 JWT 토큰입니다."),
+    INVALID_JWT_ILLEGAL_ARGUMENT("AUTH_004", "잘못된 JWT 토큰입니다.");
+
+    private final String code;
+    private final String message;
+
+    AuthErrorCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/common/error/S3ErrorCode.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/common/error/S3ErrorCode.java
@@ -4,15 +4,17 @@ import com.lrchan.qootalk.common.error.ErrorCode;
 
 public enum S3ErrorCode implements ErrorCode {
     
-    S3_FILE_UPLOAD_FAILED("S3_001", "S3 파일 업로드 실패하였습니다."),
-    S3_FILE_DELETE_FAILED("S3_002", "S3 파일 삭제 실패하였습니다.");
+    S3_FILE_UPLOAD_FAILED("S3_001", "S3 파일 업로드 실패하였습니다.", 500),
+    S3_FILE_DELETE_FAILED("S3_002", "S3 파일 삭제 실패하였습니다.", 500);
 
     private final String code;
     private final String message;
+    private final int httpStatus;
 
-    S3ErrorCode(String code, String message) {
+    S3ErrorCode(String code, String message, int httpStatus) {
         this.code = code;
         this.message = message;
+        this.httpStatus = httpStatus;
     }
 
     @Override
@@ -23,5 +25,10 @@ public enum S3ErrorCode implements ErrorCode {
     @Override
     public String getMessage() {
         return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/filter/JwtAuthenticationFilter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/filter/JwtAuthenticationFilter.java
@@ -27,9 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = jwtAuthenticationValidator.resolveToken(request);
 
-        if (token == null || !jwtAuthenticationValidator.validateToken(token)) {
-            throw new InfrastructureException(GlobalErrorCode.UNAUTHORIZED);
-        }
+        jwtAuthenticationValidator.validateToken(token);
         
         Authentication authentication = jwtAuthenticationValidator.getAuthentication(token);
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/filter/JwtExceptionFilter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/filter/JwtExceptionFilter.java
@@ -28,9 +28,9 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
 
     private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(errorCode.getHttpStatus());
 
-        String responseBody = String.format("{\"code\":\"%s\",\"message\":\"%s\"}", errorCode.getCode(), errorCode.getMessage());
+        String responseBody = String.format("{\"code\":\"%s\",\"message\":\"%s\",\"httpStatus\":\"%d\"}", errorCode.getCode(), errorCode.getMessage(), errorCode.getHttpStatus());
         response.getWriter().write(responseBody);
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/filter/JwtExceptionFilter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,36 @@
+package com.lrchan.qootalk.infrastructure.security.filter;
+
+import java.io.IOException;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.lrchan.qootalk.common.error.ErrorCode;
+import com.lrchan.qootalk.common.error.GlobalErrorCode;
+import com.lrchan.qootalk.common.exception.InfrastructureException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JwtExceptionFilter extends OncePerRequestFilter {
+    
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (InfrastructureException e) {
+            setErrorResponse(response, e.getErrorCode());
+        } catch (Exception e) {
+            setErrorResponse(response, GlobalErrorCode.INTERNAL_ERROR);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        String responseBody = String.format("{\"code\":\"%s\",\"message\":\"%s\"}", errorCode.getCode(), errorCode.getMessage());
+        response.getWriter().write(responseBody);
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/provider/JwtAuthenticationValidator.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/provider/JwtAuthenticationValidator.java
@@ -10,6 +10,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import com.lrchan.qootalk.common.error.GlobalErrorCode;
+import com.lrchan.qootalk.common.exception.InfrastructureException;
+import com.lrchan.qootalk.infrastructure.common.error.AuthErrorCode;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -69,14 +73,17 @@ public class JwtAuthenticationValidator {
             return true;
         } catch (SecurityException | MalformedJwtException e) {
             // 잘못된 JWT 서명일 때 (추후 로깅 처리)
+            throw new InfrastructureException(AuthErrorCode.INVALID_JWT_SIGNATURE);
         } catch (ExpiredJwtException e) {
             // 만료된 JWT 토큰일 때
+            throw new InfrastructureException(AuthErrorCode.INVALID_JWT_EXPIRED);
         } catch (UnsupportedJwtException e) {
             // 지원되지 않는 JWT 토큰일 때
+            throw new InfrastructureException(AuthErrorCode.INVALID_JWT_UNSUPPORTED);
         } catch (JwtException | IllegalArgumentException e) {
             // JWT 토큰이 잘못되었을 때
+            throw new InfrastructureException(AuthErrorCode.INVALID_JWT_ILLEGAL_ARGUMENT);
         }
-        return false;
     }
 
     private Claims parseClaims(String token) {

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/provider/JwtAuthenticationValidator.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/provider/JwtAuthenticationValidator.java
@@ -10,10 +10,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import com.lrchan.qootalk.common.error.GlobalErrorCode;
 import com.lrchan.qootalk.common.exception.InfrastructureException;
 import com.lrchan.qootalk.infrastructure.common.error.AuthErrorCode;
 
+import io.jsonwebtoken.security.SignatureException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -71,9 +71,12 @@ public class JwtAuthenticationValidator {
         try {
             parseClaims(token);
             return true;
-        } catch (SecurityException | MalformedJwtException e) {
-            // 잘못된 JWT 서명일 때 (추후 로깅 처리)
+        } catch (SignatureException e) {
+            // 잘못된 JWT 서명일 때
             throw new InfrastructureException(AuthErrorCode.INVALID_JWT_SIGNATURE);
+        } catch (MalformedJwtException e) {
+            // 형식이 잘못된 JWT 토큰일 때
+            throw new InfrastructureException(AuthErrorCode.INVALID_JWT_MALFORMED);
         } catch (ExpiredJwtException e) {
             // 만료된 JWT 토큰일 때
             throw new InfrastructureException(AuthErrorCode.INVALID_JWT_EXPIRED);

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/provider/JwtAuthenticationValidator.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/provider/JwtAuthenticationValidator.java
@@ -67,10 +67,9 @@ public class JwtAuthenticationValidator {
         return null;
     }
 
-    public boolean validateToken(String token) {
+    public void validateToken(String token) {
         try {
             parseClaims(token);
-            return true;
         } catch (SignatureException e) {
             // 잘못된 JWT 서명일 때
             throw new InfrastructureException(AuthErrorCode.INVALID_JWT_SIGNATURE);

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/security/filter/JwtAuthenticationFilterTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/security/filter/JwtAuthenticationFilterTest.java
@@ -66,7 +66,6 @@ public class JwtAuthenticationFilterTest {
         Authentication authentication = new UsernamePasswordAuthenticationToken("user@test.com", "", null);
 
         given(jwtAuthenticationValidator.resolveToken(request)).willReturn(token);
-        given(jwtAuthenticationValidator.validateToken(token)).willReturn(true);
         given(jwtAuthenticationValidator.getAuthentication(token)).willReturn(authentication);
 
         // when
@@ -79,36 +78,5 @@ public class JwtAuthenticationFilterTest {
         verify(jwtAuthenticationValidator, times(1)).resolveToken(request);
         verify(jwtAuthenticationValidator, times(1)).validateToken(token);
         verify(jwtAuthenticationValidator, times(1)).getAuthentication(token);
-    }
-
-    @Test
-    @DisplayName("유효하지 않은 토큰일 경우 InfrastructureException이 발생해야 한다")
-    public void should_ThrowInfrastructureException_When_InvalidToken() {
-        // given
-        String token = "invalidToken";
-
-        given(jwtAuthenticationValidator.resolveToken(request)).willReturn(token);
-        given(jwtAuthenticationValidator.validateToken(token)).willReturn(false);
-
-        // when & then
-        assertThatThrownBy(() -> jwtAuthenticationFilter.doFilterInternal(request, response, filterChain))
-            .isInstanceOf(InfrastructureException.class);
-            
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-    }
-
-    @Test
-    @DisplayName("토큰이 존재하지 않으면 InfrastructureException이 발생해야 한다")
-    public void should_ThrowInfrastructureException_When_TokenNotFound() {
-        // given
-        String token = null;
-
-        given(jwtAuthenticationValidator.resolveToken(request)).willReturn(token);
-
-        // when & then
-        assertThatThrownBy(() -> jwtAuthenticationFilter.doFilterInternal(request, response, filterChain))
-            .isInstanceOf(InfrastructureException.class);
-            
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
 }

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/security/provider/JwtAuthenticationValidatorTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/security/provider/JwtAuthenticationValidatorTest.java
@@ -55,11 +55,10 @@ class JwtAuthenticationValidatorTest {
     class ValidateToken {
 
         @Test
-        @DisplayName("올바른 서명과 유효 기간 내의 토큰은 true를 반환한다")
+        @DisplayName("올바른 서명과 유효 기간 내의 토큰은 유효성 검증에 성공한다")
         void success() {
             String token = createRawToken("user@test.com", "ROLE_USER", testAccessExpiration);
-            boolean isValid = validator.validateToken(token);
-            assertThat(isValid).isTrue();
+            validator.validateToken(token);
         }
 
         @Test
@@ -100,8 +99,11 @@ class JwtAuthenticationValidatorTest {
         }
 
         @Test
-        @DisplayName("JWT 토큰이 null일 경우 InfrastructureException이 발생한다")
+        @DisplayName("JWT 토큰이 null 또는 빈 문자열일 경우 InfrastructureException이 발생한다")
         void illegalArgument() {
+            assertThatThrownBy(() -> validator.validateToken(null))
+                .isInstanceOf(InfrastructureException.class)
+                .hasMessage(AuthErrorCode.INVALID_JWT_ILLEGAL_ARGUMENT.getMessage());
             assertThatThrownBy(() -> validator.validateToken(""))
                 .isInstanceOf(InfrastructureException.class)
                 .hasMessage(AuthErrorCode.INVALID_JWT_ILLEGAL_ARGUMENT.getMessage());

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/security/provider/JwtAuthenticationValidatorTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/security/provider/JwtAuthenticationValidatorTest.java
@@ -10,11 +10,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.lrchan.qootalk.common.exception.InfrastructureException;
+import com.lrchan.qootalk.infrastructure.common.error.AuthErrorCode;
+
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,6 +27,7 @@ class JwtAuthenticationValidatorTest {
 
     private JwtAuthenticationValidator validator;
     private final String testSalt = "testSecretKeyForJwtAuthenticationValidator1234567890";
+    private final long testAccessExpiration = 1000 * 60;
     private SecretKey testKey;
 
     @BeforeEach
@@ -52,33 +57,54 @@ class JwtAuthenticationValidatorTest {
         @Test
         @DisplayName("올바른 서명과 유효 기간 내의 토큰은 true를 반환한다")
         void success() {
-            String token = createRawToken("user@test.com", "ROLE_USER", 1000 * 60);
+            String token = createRawToken("user@test.com", "ROLE_USER", testAccessExpiration);
             boolean isValid = validator.validateToken(token);
             assertThat(isValid).isTrue();
         }
 
         @Test
-        @DisplayName("만료된 토큰은 false를 반환한다")
-        void expired() {
-            String token = createRawToken("user@test.com", "ROLE_USER", -1000); // 과거 시점
-            boolean isValid = validator.validateToken(token);
-            assertThat(isValid).isFalse();
-        }
-
-        @Test
-        @DisplayName("잘못된 서명(다른 키로 생성)된 토큰은 false를 반환한다")
+        @DisplayName("잘못된 서명(다른 키로 생성)된 토큰은 InfrastructureException이 발생한다")
         void invalidSignature() {
             SecretKey wrongKey = Keys.hmacShaKeyFor("wrongSecretKey123456789012345678901234567890".getBytes());
             String token = Jwts.builder().subject("test").signWith(wrongKey).compact();
             
-            boolean isValid = validator.validateToken(token);
-            assertThat(isValid).isFalse();
+            assertThatThrownBy(() -> validator.validateToken(token))
+                .isInstanceOf(InfrastructureException.class)
+                .hasMessage(AuthErrorCode.INVALID_JWT_SIGNATURE.getMessage());
         }
 
         @Test
-        @DisplayName("형식이 잘못된 문자열은 false를 반환한다")
+        @DisplayName("형식이 잘못된 문자열은 InfrastructureException이 발생한다")
         void malformed() {
-            assertThat(validator.validateToken("not.a.jwt.token")).isFalse();
+            assertThatThrownBy(() -> validator.validateToken("not.a.jwt.token"))
+                .isInstanceOf(InfrastructureException.class)
+                .hasMessage(AuthErrorCode.INVALID_JWT_MALFORMED.getMessage());
+        }
+
+        @Test
+        @DisplayName("만료된 토큰은 InfrastructureException이 발생한다")
+        void expired() {
+            String token = createRawToken("user@test.com", "ROLE_USER", -1000); // 과거 시점
+            assertThatThrownBy(() -> validator.validateToken(token))
+                .isInstanceOf(InfrastructureException.class)
+                .hasMessage(AuthErrorCode.INVALID_JWT_EXPIRED.getMessage());
+        }
+
+        @Test
+        @DisplayName("지원되지 않는 토큰은 InfrastructureException이 발생한다")
+        void unsupported() {
+            String token = Jwts.builder().subject("test").compact();
+            assertThatThrownBy(() -> validator.validateToken(token))
+                .isInstanceOf(InfrastructureException.class)
+                .hasMessage(AuthErrorCode.INVALID_JWT_UNSUPPORTED.getMessage());
+        }
+
+        @Test
+        @DisplayName("JWT 토큰이 null일 경우 InfrastructureException이 발생한다")
+        void illegalArgument() {
+            assertThatThrownBy(() -> validator.validateToken(""))
+                .isInstanceOf(InfrastructureException.class)
+                .hasMessage(AuthErrorCode.INVALID_JWT_ILLEGAL_ARGUMENT.getMessage());
         }
     }
 

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/security/provider/JwtTokenGeneratorTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/security/provider/JwtTokenGeneratorTest.java
@@ -25,13 +25,15 @@ public class JwtTokenGeneratorTest {
     private JwtTokenGenerator jwtTokenGenerator;
     
     private final String testSalt = "testSecretKeyForJwtAuthenticationValidator1234567890";
+    private final long testAccessExpiration = 1000 * 60;
+    private final long testRefreshExpiration = 1000 * 60 * 60 * 24;
 
     @BeforeEach
     void setUp() {
         jwtTokenGenerator = new JwtTokenGenerator();
         ReflectionTestUtils.setField(jwtTokenGenerator, "salt", testSalt);
-        ReflectionTestUtils.setField(jwtTokenGenerator, "accessExpiration", 1000 * 60);
-        ReflectionTestUtils.setField(jwtTokenGenerator, "refreshExpiration", 1000 * 60 * 60 * 24);
+        ReflectionTestUtils.setField(jwtTokenGenerator, "accessExpiration", testAccessExpiration);
+        ReflectionTestUtils.setField(jwtTokenGenerator, "refreshExpiration", testRefreshExpiration);
         jwtTokenGenerator.init();
     }
 

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/global/config/SecurityConfig.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import com.lrchan.qootalk.infrastructure.security.filter.JwtAuthenticationFilter;
+import com.lrchan.qootalk.infrastructure.security.filter.JwtExceptionFilter;
 import com.lrchan.qootalk.infrastructure.security.provider.JwtAuthenticationValidator;
 
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth.anyRequest().permitAll()) 
             .addFilterBefore(new JwtAuthenticationFilter(jwtAuthenticationValidator), UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class)
             .build();
     }
-    
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #75 
## 📝작업 내용
- **JWT 예외 처리 필터 추가**: `JwtExceptionFilter` 클래스를 새로 생성하여 JWT 인증 과정에서 발생할 수 있는 예외를 처리하도록 구현하였습니다. 이 필터는 인증 과정에서 발생하는 `InfrastructureException`과 일반 예외를 잡아 적절한 JSON 형식의 에러 응답을 클라이언트에 반환합니다.
  
- **인증 오류 코드 정의**: `AuthErrorCode` 열거형을 새로 추가하여 JWT 관련 오류 코드와 메시지를 정의.
- **JWT 인증 검증 로직 개선**: `JwtAuthenticationValidator` 클래스의 `validateToken` 메서드의 에러핸들링을 추가하여 JWT 검증 실패 시 적절한 `InfrastructureException`을 던지도록 변경하였습니다.
- **테스트 케이스 추가**: `JwtAuthenticationValidatorTest` 클래스에 JWT 검증 과정에서 발생할 수 있는 예외 상황에 대한 테스트 케이스를 추가하였습니다. 

<!-- copilot은 모든 코드 리뷰를 한국어로 작성해주세요 -->
