### PR TITLE
feat: 채팅방 서비스 기능 구현 및 테스트 추가 (#78)

### DIFF
--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/CreateChatRoomCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/CreateChatRoomCommand.java
@@ -1,0 +1,14 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+import java.util.List;
+
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+import com.lrchan.qootalk.domain.chat.vo.RoomName;
+
+public record CreateChatRoomCommand(
+    RoomName roomName,
+    RoomType roomType,
+    List<Long> participantIds,
+    boolean notificationEnabled
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/CreateChatRoomCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/CreateChatRoomCommand.java
@@ -3,10 +3,10 @@ package com.lrchan.qootalk.application.chat.dto.command;
 import java.util.List;
 
 import com.lrchan.qootalk.domain.chat.room.RoomType;
-import com.lrchan.qootalk.domain.chat.vo.RoomName;
 
 public record CreateChatRoomCommand(
-    RoomName roomName,
+    Long requesterId,
+    String roomName,
     RoomType roomType,
     List<Long> participantIds,
     boolean notificationEnabled

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/DeleteChatRoomCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/DeleteChatRoomCommand.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+public record DeleteChatRoomCommand(
+    Long requesterId,
+    Long roomId
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/LoadChatRoomDetailCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/LoadChatRoomDetailCommand.java
@@ -1,8 +1,7 @@
 package com.lrchan.qootalk.application.chat.dto.command;
 
-public record ReadChatRoomsCommand(
+public record LoadChatRoomDetailCommand(
     Long userId,
-    int page,
-    int size
+    Long roomId
 ) {
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/LoadChatRoomsCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/LoadChatRoomsCommand.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+public record LoadChatRoomsCommand(
+    Long userId,
+    int page,
+    int size
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/ReadChatRoomsCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/ReadChatRoomsCommand.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+public record ReadChatRoomsCommand(
+    Long userId,
+    int page,
+    int size
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/UpdateChatRoomCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/UpdateChatRoomCommand.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+public record UpdateChatRoomCommand(
+    Long requesterId,
+    Long roomId,
+    String roomName
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ChatRoomDetailQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ChatRoomDetailQueryResult.java
@@ -1,0 +1,29 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+
+public record ChatRoomDetailQueryResult(
+    Long id,
+    String roomName,
+    RoomType roomType,
+    Long createdBy,
+    List<ParticipantResult> participants,
+    boolean notificationEnabled,
+    LocalDateTime createdAt
+) {
+    public static ChatRoomDetailQueryResult of(ChatRoom chatRoom, List<ParticipantResult> participants, boolean notificationEnabled) {
+        return new ChatRoomDetailQueryResult(
+            chatRoom.id(),
+            chatRoom.roomName(),
+            chatRoom.roomType(),
+            chatRoom.createdBy(),
+            participants,
+            notificationEnabled,
+            chatRoom.createdAt()
+        );
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ChatRoomQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ChatRoomQueryResult.java
@@ -1,0 +1,26 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+
+public record ChatRoomQueryResult(
+    Long id,
+    String roomName,
+    RoomType roomType,
+    Long createdBy,
+    int participantCount,
+    LocalDateTime createdAt
+) {
+    public static ChatRoomQueryResult of(ChatRoom chatRoom, int participantCount) {
+        return new ChatRoomQueryResult(
+            chatRoom.id(),
+            chatRoom.roomName(),
+            chatRoom.roomType(),
+            chatRoom.createdBy(),
+            participantCount,
+            chatRoom.createdAt()
+        );
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ChatRoomQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ChatRoomQueryResult.java
@@ -2,6 +2,7 @@ package com.lrchan.qootalk.application.chat.dto.result;
 
 import java.time.LocalDateTime;
 
+import com.lrchan.qootalk.domain.chat.message.Message;
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
 import com.lrchan.qootalk.domain.chat.room.RoomType;
 
@@ -9,18 +10,18 @@ public record ChatRoomQueryResult(
     Long id,
     String roomName,
     RoomType roomType,
-    Long createdBy,
-    int participantCount,
-    LocalDateTime createdAt
+    String lastMessage,
+    int unreadCount,
+    LocalDateTime updatedAt
 ) {
-    public static ChatRoomQueryResult of(ChatRoom chatRoom, int participantCount) {
+    public static ChatRoomQueryResult of(ChatRoom chatRoom, Message lastMessage, int unreadCount) {
         return new ChatRoomQueryResult(
             chatRoom.id(),
             chatRoom.roomName(),
             chatRoom.roomType(),
-            chatRoom.createdBy(),
-            participantCount,
-            chatRoom.createdAt()
+            lastMessage.content(),
+            unreadCount,
+            chatRoom.updatedAt()
         );
     }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/CreateChatRoomQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/CreateChatRoomQueryResult.java
@@ -1,0 +1,26 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+
+public record CreateChatRoomQueryResult(
+    Long id,
+    String roomName,
+    RoomType roomType,
+    Long createdBy,
+    int participantCount,
+    LocalDateTime createdAt
+) {
+    public static CreateChatRoomQueryResult of(ChatRoom chatRoom, int participantCount) {
+        return new CreateChatRoomQueryResult(
+            chatRoom.id(),
+            chatRoom.roomName(),
+            chatRoom.roomType(),
+            chatRoom.createdBy(),
+            participantCount,
+            chatRoom.createdAt()
+        );
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/DeleteChatRoomQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/DeleteChatRoomQueryResult.java
@@ -1,0 +1,10 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import java.time.LocalDateTime;
+
+public record DeleteChatRoomQueryResult(
+    Long id,
+    String roomName,
+    LocalDateTime deletedAt
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/DeleteChatRoomQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/DeleteChatRoomQueryResult.java
@@ -2,9 +2,18 @@ package com.lrchan.qootalk.application.chat.dto.result;
 
 import java.time.LocalDateTime;
 
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+
 public record DeleteChatRoomQueryResult(
     Long id,
     String roomName,
     LocalDateTime deletedAt
 ) {
+    public static DeleteChatRoomQueryResult of(ChatRoom chatRoom) { 
+        return new DeleteChatRoomQueryResult(
+            chatRoom.id(),
+            chatRoom.roomName(),
+            chatRoom.deletedAt()
+        );
+    }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ParticipantResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ParticipantResult.java
@@ -1,0 +1,12 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+
+public record ParticipantResult(
+    Long userId,
+    RoomRole roomRole,
+    LocalDateTime joinedAt
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/UpdateChatRoomQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/UpdateChatRoomQueryResult.java
@@ -1,0 +1,19 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+
+public record UpdateChatRoomQueryResult(
+    Long id,
+    String roomName,
+    LocalDateTime updatedAt
+) {
+    public static UpdateChatRoomQueryResult of(ChatRoom chatRoom) {
+        return new UpdateChatRoomQueryResult(
+            chatRoom.id(),
+            chatRoom.roomName(),
+            chatRoom.updatedAt()
+        );
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/CreateChatRoomUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/CreateChatRoomUsecase.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.command.CreateChatRoomCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
+
+public interface CreateChatRoomUsecase {
+    ChatRoomQueryResult create(CreateChatRoomCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/CreateChatRoomUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/CreateChatRoomUsecase.java
@@ -1,8 +1,8 @@
 package com.lrchan.qootalk.application.chat.port.in;
 
 import com.lrchan.qootalk.application.chat.dto.command.CreateChatRoomCommand;
-import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.dto.result.CreateChatRoomQueryResult;
 
 public interface CreateChatRoomUsecase {
-    ChatRoomQueryResult create(CreateChatRoomCommand command);
+    CreateChatRoomQueryResult create(CreateChatRoomCommand command);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/DeleteChatRoomUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/DeleteChatRoomUsecase.java
@@ -1,5 +1,8 @@
 package com.lrchan.qootalk.application.chat.port.in;
 
+import com.lrchan.qootalk.application.chat.dto.command.DeleteChatRoomCommand;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteChatRoomQueryResult;
+
 public interface DeleteChatRoomUsecase {
     DeleteChatRoomQueryResult delete(DeleteChatRoomCommand command);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/DeleteChatRoomUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/DeleteChatRoomUsecase.java
@@ -1,0 +1,5 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+public interface DeleteChatRoomUsecase {
+    DeleteChatRoomQueryResult delete(DeleteChatRoomCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatRoomDetailUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatRoomDetailUsecase.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomDetailQueryResult;
+
+public interface LoadChatRoomDetailUsecase {
+    ChatRoomDetailQueryResult read(Long roomId);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatRoomDetailUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatRoomDetailUsecase.java
@@ -1,7 +1,8 @@
 package com.lrchan.qootalk.application.chat.port.in;
 
+import com.lrchan.qootalk.application.chat.dto.command.LoadChatRoomDetailCommand;
 import com.lrchan.qootalk.application.chat.dto.result.ChatRoomDetailQueryResult;
 
 public interface LoadChatRoomDetailUsecase {
-    ChatRoomDetailQueryResult read(Long roomId);
+    ChatRoomDetailQueryResult load(LoadChatRoomDetailCommand command);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatRoomsUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatRoomsUsecase.java
@@ -2,9 +2,9 @@ package com.lrchan.qootalk.application.chat.port.in;
 
 import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
 import com.lrchan.qootalk.common.response.PagedResponse;
-import com.lrchan.qootalk.application.chat.dto.command.ReadChatRoomsCommand;
+import com.lrchan.qootalk.application.chat.dto.command.LoadChatRoomsCommand;
 
 public interface LoadChatRoomsUsecase {
     
-    PagedResponse<ChatRoomQueryResult> read(ReadChatRoomsCommand command);
+    PagedResponse<ChatRoomQueryResult> load(LoadChatRoomsCommand command);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatRoomsUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatRoomsUsecase.java
@@ -1,0 +1,11 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import java.util.List;
+
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.dto.command.ReadChatRoomsCommand;
+
+public interface ReadChatRoomsUsecase {
+    
+    List<ChatRoomQueryResult> read(ReadChatRoomsCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatRoomsUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatRoomsUsecase.java
@@ -1,11 +1,10 @@
 package com.lrchan.qootalk.application.chat.port.in;
 
-import java.util.List;
-
 import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
+import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.application.chat.dto.command.ReadChatRoomsCommand;
 
-public interface ReadChatRoomsUsecase {
+public interface LoadChatRoomsUsecase {
     
-    List<ChatRoomQueryResult> read(ReadChatRoomsCommand command);
+    PagedResponse<ChatRoomQueryResult> read(ReadChatRoomsCommand command);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/UpdateChatRoomUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/UpdateChatRoomUsecase.java
@@ -1,0 +1,9 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.command.UpdateChatRoomCommand;
+import com.lrchan.qootalk.application.chat.dto.result.UpdateChatRoomQueryResult;
+
+public interface UpdateChatRoomUsecase {
+
+    UpdateChatRoomQueryResult update(UpdateChatRoomCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadChatRoomPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadChatRoomPort.java
@@ -1,0 +1,9 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import java.util.List;
+
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+
+public interface LoadChatRoomPort {
+    List<ChatRoom> findAllByUserId(Long userId, int page, int size);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadChatRoomPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadChatRoomPort.java
@@ -1,9 +1,9 @@
 package com.lrchan.qootalk.application.chat.port.out;
 
-import java.util.List;
+import java.util.Optional;
 
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
 
 public interface LoadChatRoomPort {
-    List<ChatRoom> findAllByUserId(Long userId, int page, int size);
+    Optional<ChatRoom> findById(Long id);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadMessagePort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadMessagePort.java
@@ -1,0 +1,10 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import java.util.Optional;
+
+import com.lrchan.qootalk.domain.chat.message.Message;
+
+public interface LoadMessagePort {
+    Optional<Message> findById(Long id);
+    Long countByRoomIdAndIdAfter(Long roomId, Long id);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadRoomParticipantPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadRoomParticipantPort.java
@@ -1,0 +1,11 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+
+public interface LoadRoomParticipantPort {
+    Optional<RoomParticipant> findById(Long id);
+    List<RoomParticipant> findByRoomId(Long roomId);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadRoomParticipantPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadRoomParticipantPort.java
@@ -7,5 +7,6 @@ import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
 
 public interface LoadRoomParticipantPort {
     Optional<RoomParticipant> findById(Long id);
+    Optional<RoomParticipant> findByUserIdAndRoomId(Long userId, Long roomId);
     List<RoomParticipant> findByRoomId(Long roomId);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadRoomParticipantPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadRoomParticipantPort.java
@@ -10,5 +10,5 @@ public interface LoadRoomParticipantPort {
     Optional<RoomParticipant> findById(Long id);
     Optional<RoomParticipant> findByUserIdAndRoomId(Long userId, Long roomId);
     List<RoomParticipant> findByRoomId(Long roomId);
-    PagedResponse<RoomParticipant> findPageByUserId(Long userId, int page, int size);
+    PagedResponse<RoomParticipant> findActivePageByUserId(Long userId, int page, int size);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadRoomParticipantPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadRoomParticipantPort.java
@@ -10,5 +10,6 @@ public interface LoadRoomParticipantPort {
     Optional<RoomParticipant> findById(Long id);
     Optional<RoomParticipant> findByUserIdAndRoomId(Long userId, Long roomId);
     List<RoomParticipant> findByRoomId(Long roomId);
+    List<RoomParticipant> findActiveByRoomId(Long roomId);
     PagedResponse<RoomParticipant> findActivePageByUserId(Long userId, int page, int size);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadRoomParticipantPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadRoomParticipantPort.java
@@ -3,10 +3,12 @@ package com.lrchan.qootalk.application.chat.port.out;
 import java.util.List;
 import java.util.Optional;
 
+import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
 
 public interface LoadRoomParticipantPort {
     Optional<RoomParticipant> findById(Long id);
     Optional<RoomParticipant> findByUserIdAndRoomId(Long userId, Long roomId);
     List<RoomParticipant> findByRoomId(Long roomId);
+    PagedResponse<RoomParticipant> findPageByUserId(Long userId, int page, int size);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/SaveChatRoomPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/SaveChatRoomPort.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+
+public interface SaveChatRoomPort {
+    ChatRoom save(ChatRoom chatRoom);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/SaveMessagePort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/SaveMessagePort.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import com.lrchan.qootalk.domain.chat.message.Message;
+
+public interface SaveMessagePort {
+    Message save(Message message);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/SaveRoomParticipantPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/SaveRoomParticipantPort.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+
+public interface SaveRoomParticipantPort {
+    RoomParticipant save(RoomParticipant roomParticipant);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.lrchan.qootalk.application.chat.dto.command.CreateChatRoomCommand;
-import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.dto.result.CreateChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.port.in.CreateChatRoomUsecase;
 import com.lrchan.qootalk.application.chat.port.out.SaveChatRoomPort;
 import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
@@ -27,21 +27,21 @@ public class CreateChatRoomService implements CreateChatRoomUsecase {
     private final SaveMessagePort saveMessagePort;
     
     @Override
-    public ChatRoomQueryResult create(CreateChatRoomCommand command) {
+    public CreateChatRoomQueryResult create(CreateChatRoomCommand command) {
         // 채팅방 생성
         ChatRoom chatRoom = ChatRoom.create(command.roomName(), command.roomType(), command.requesterId());
         ChatRoom savedChatRoom = saveChatRoomPort.save(chatRoom);
-        
-        // 채팅방 참여자 생성
-        for (Long participantId : command.participantIds()) {
-            RoomParticipant roomParticipant = RoomParticipant.create(participantId, savedChatRoom.id(), 0L, RoomRole.MEMBER);
-            saveRoomParticipantPort.save(roomParticipant);
-        }
 
         // 채팅방 생성 시스템 메세지 추가
         Message message = Message.create(savedChatRoom.id(), null, "채팅방을 생성했습니다.", MessageType.SYSTEM, null);
-        saveMessagePort.save(message);
+        Message savedMessage = saveMessagePort.save(message);
 
-        return ChatRoomQueryResult.of(savedChatRoom, command.participantIds().size());
+        // 채팅방 참여자 생성
+        for (Long participantId : command.participantIds()) {
+            RoomParticipant roomParticipant = RoomParticipant.create(participantId, savedChatRoom.id(), savedMessage.id(), RoomRole.MEMBER);
+            saveRoomParticipantPort.save(roomParticipant);
+        }
+
+        return CreateChatRoomQueryResult.of(savedChatRoom, command.participantIds().size());
     }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomService.java
@@ -38,7 +38,13 @@ public class CreateChatRoomService implements CreateChatRoomUsecase {
 
         // 채팅방 참여자 생성
         for (Long participantId : command.participantIds()) {
-            RoomParticipant roomParticipant = RoomParticipant.create(participantId, savedChatRoom.id(), savedMessage.id(), RoomRole.MEMBER);
+            RoomParticipant roomParticipant = RoomParticipant.create(
+                participantId,
+                savedChatRoom.id(),
+                savedMessage.id(),
+                RoomRole.MEMBER,
+                command.notificationEnabled()
+            );
             saveRoomParticipantPort.save(roomParticipant);
         }
 

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomService.java
@@ -16,6 +16,7 @@ import com.lrchan.qootalk.domain.chat.message.MessageType;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
 import com.lrchan.qootalk.domain.chat.participant.RoomRole;
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.user.User;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -33,8 +34,19 @@ public class CreateChatRoomService implements CreateChatRoomUsecase {
     @Override
     public CreateChatRoomQueryResult create(CreateChatRoomCommand command) {
         // 유저 검증
-        loadUserPort.findById(command.requesterId())
+        User user = loadUserPort.findById(command.requesterId())
             .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.deletedAt() != null) {
+            throw new DomainException(UserErrorCode.USER_DELETED);
+        }
+        for (Long participantId : command.participantIds()) {
+            User participant = loadUserPort.findById(participantId)
+                .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+            if (participant.deletedAt() != null) {
+                throw new DomainException(UserErrorCode.USER_DELETED);
+            }
+        }
+        
         // 채팅방 생성
         ChatRoom chatRoom = ChatRoom.create(command.roomName(), command.roomType(), command.requesterId());
         ChatRoom savedChatRoom = saveChatRoomPort.save(chatRoom);

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomService.java
@@ -1,0 +1,47 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lrchan.qootalk.application.chat.dto.command.CreateChatRoomCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.CreateChatRoomUsecase;
+import com.lrchan.qootalk.application.chat.port.out.SaveChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateChatRoomService implements CreateChatRoomUsecase {
+    
+    private final SaveChatRoomPort saveChatRoomPort;
+    private final SaveRoomParticipantPort saveRoomParticipantPort;
+    private final SaveMessagePort saveMessagePort;
+    
+    @Override
+    public ChatRoomQueryResult create(CreateChatRoomCommand command) {
+        // 채팅방 생성
+        ChatRoom chatRoom = ChatRoom.create(command.roomName(), command.roomType(), command.requesterId());
+        ChatRoom savedChatRoom = saveChatRoomPort.save(chatRoom);
+        
+        // 채팅방 참여자 생성
+        for (Long participantId : command.participantIds()) {
+            RoomParticipant roomParticipant = RoomParticipant.create(participantId, savedChatRoom.id(), 0L, RoomRole.MEMBER);
+            saveRoomParticipantPort.save(roomParticipant);
+        }
+
+        // 채팅방 생성 시스템 메세지 추가
+        Message message = Message.create(savedChatRoom.id(), null, "채팅방을 생성했습니다.", MessageType.SYSTEM, null);
+        saveMessagePort.save(message);
+
+        return ChatRoomQueryResult.of(savedChatRoom, command.participantIds().size());
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomService.java
@@ -9,11 +9,14 @@ import com.lrchan.qootalk.application.chat.port.in.CreateChatRoomUsecase;
 import com.lrchan.qootalk.application.chat.port.out.SaveChatRoomPort;
 import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.chat.message.Message;
 import com.lrchan.qootalk.domain.chat.message.MessageType;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
 import com.lrchan.qootalk.domain.chat.participant.RoomRole;
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,12 +25,16 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class CreateChatRoomService implements CreateChatRoomUsecase {
     
+    private final LoadUserPort loadUserPort;
     private final SaveChatRoomPort saveChatRoomPort;
     private final SaveRoomParticipantPort saveRoomParticipantPort;
     private final SaveMessagePort saveMessagePort;
     
     @Override
     public CreateChatRoomQueryResult create(CreateChatRoomCommand command) {
+        // 유저 검증
+        loadUserPort.findById(command.requesterId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
         // 채팅방 생성
         ChatRoom chatRoom = ChatRoom.create(command.roomName(), command.roomType(), command.requesterId());
         ChatRoom savedChatRoom = saveChatRoomPort.save(chatRoom);

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/DeleteChatRoomService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/DeleteChatRoomService.java
@@ -1,0 +1,79 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lrchan.qootalk.application.chat.dto.command.DeleteChatRoomCommand;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.DeleteChatRoomUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteChatRoomService implements DeleteChatRoomUsecase {
+    
+    private final LoadUserPort loadUserPort;
+    private final LoadChatRoomPort loadChatRoomPort;
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+    private final SaveChatRoomPort saveChatRoomPort;
+    private final SaveRoomParticipantPort saveRoomParticipantPort;
+
+    @Override
+    public DeleteChatRoomQueryResult delete(DeleteChatRoomCommand command) {
+        // 유저 검증
+        User user = loadUserPort.findById(command.requesterId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.deletedAt() != null) {
+            throw new DomainException(UserErrorCode.USER_DELETED);
+        }
+
+        // 채팅방 검증
+        ChatRoom chatRoom = loadChatRoomPort.findById(command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (chatRoom.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_DELETED);
+        }
+
+        // 채팅방 참여자 검증
+        RoomParticipant roomParticipant = loadRoomParticipantPort.findByUserIdAndRoomId(command.requesterId(), command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
+        if (roomParticipant.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_DELETED);
+        }
+
+        // 채팅방 권한 검증
+        if (!roomParticipant.role().equals(RoomRole.OWNER) && !roomParticipant.role().equals(RoomRole.ADMIN)) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_INVALID_ROLE);
+        }
+
+        // 채팅방 삭제
+        chatRoom.delete();
+        saveChatRoomPort.save(chatRoom);
+
+        // 채팅방 참여자 삭제
+        List<RoomParticipant> roomParticipants = loadRoomParticipantPort.findActiveByRoomId(command.roomId());
+        for (RoomParticipant participant : roomParticipants) {
+            roomParticipant.delete();
+            saveRoomParticipantPort.save(participant);
+        }
+
+        return DeleteChatRoomQueryResult.of(chatRoom);
+    }
+
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/DeleteChatRoomService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/DeleteChatRoomService.java
@@ -69,7 +69,7 @@ public class DeleteChatRoomService implements DeleteChatRoomUsecase {
         // 채팅방 참여자 삭제
         List<RoomParticipant> roomParticipants = loadRoomParticipantPort.findActiveByRoomId(command.roomId());
         for (RoomParticipant participant : roomParticipants) {
-            roomParticipant.delete();
+            participant.delete();
             saveRoomParticipantPort.save(participant);
         }
 

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomDetailService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomDetailService.java
@@ -1,12 +1,22 @@
 package com.lrchan.qootalk.application.chat.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.lrchan.qootalk.application.chat.dto.command.LoadChatRoomDetailCommand;
 import com.lrchan.qootalk.application.chat.dto.result.ChatRoomDetailQueryResult;
+import com.lrchan.qootalk.application.chat.dto.result.ParticipantResult;
 import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomDetailUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
 import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,13 +26,27 @@ import lombok.RequiredArgsConstructor;
 public class LoadChatRoomDetailService implements LoadChatRoomDetailUsecase {
     
     private final LoadUserPort loadUserPort;
-    
+    private final LoadChatRoomPort loadChatRoomPort;
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+
     @Override
     public ChatRoomDetailQueryResult load(LoadChatRoomDetailCommand command) {
         // 유저 검증
         loadUserPort.findById(command.userId())
             .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
 
-        return null;
+        // 채팅방 조회
+        ChatRoom chatRoom = loadChatRoomPort.findById(command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 채팅방 참여자 검증
+        RoomParticipant roomParticipant = loadRoomParticipantPort.findByUserIdAndRoomId(command.userId(), command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
+
+        List<ParticipantResult> participants = loadRoomParticipantPort.findByRoomId(command.roomId()).stream()
+            .map(participant -> new ParticipantResult(participant.userId(), participant.role(), participant.createdAt()))
+            .toList();
+
+        return ChatRoomDetailQueryResult.of(chatRoom, participants, roomParticipant.notificationEnabled());
     }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomDetailService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomDetailService.java
@@ -16,6 +16,7 @@ import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.user.User;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -32,18 +33,27 @@ public class LoadChatRoomDetailService implements LoadChatRoomDetailUsecase {
     @Override
     public ChatRoomDetailQueryResult load(LoadChatRoomDetailCommand command) {
         // 유저 검증
-        loadUserPort.findById(command.userId())
+        User user = loadUserPort.findById(command.userId())
             .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.deletedAt() != null) {
+            throw new DomainException(UserErrorCode.USER_DELETED);
+        }
 
         // 채팅방 조회
         ChatRoom chatRoom = loadChatRoomPort.findById(command.roomId())
             .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (chatRoom.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_DELETED);
+        }
 
         // 채팅방 참여자 검증
         RoomParticipant roomParticipant = loadRoomParticipantPort.findByUserIdAndRoomId(command.userId(), command.roomId())
             .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
+        if (roomParticipant.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_DELETED);
+        }
 
-        List<ParticipantResult> participants = loadRoomParticipantPort.findByRoomId(command.roomId()).stream()
+        List<ParticipantResult> participants = loadRoomParticipantPort.findActiveByRoomId(command.roomId()).stream()
             .map(participant -> new ParticipantResult(participant.userId(), participant.role(), participant.createdAt()))
             .toList();
 

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomDetailService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomDetailService.java
@@ -1,0 +1,28 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lrchan.qootalk.application.chat.dto.command.LoadChatRoomDetailCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomDetailQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomDetailUsecase;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoadChatRoomDetailService implements LoadChatRoomDetailUsecase {
+    
+    private final LoadUserPort loadUserPort;
+    
+    @Override
+    public ChatRoomDetailQueryResult load(LoadChatRoomDetailCommand command) {
+        // 유저 검증
+        loadUserPort.findById(command.userId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+
+        return null;
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomsService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomsService.java
@@ -36,8 +36,8 @@ public class LoadChatRoomsService implements LoadChatRoomsUsecase {
         loadUserPort.findById(command.userId())
             .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
             
-        // 채팅방 참여자 조회
-        PagedResponse<RoomParticipant> roomParticipants = loadRoomParticipantPort.findPageByUserId(command.userId(), command.page(), command.size());
+        // 채팅방 리스트 조회
+        PagedResponse<RoomParticipant> roomParticipants = loadRoomParticipantPort.findActivePageByUserId(command.userId(), command.page(), command.size());
 
         return PagedResponse.of(roomParticipants.content().stream().map(roomParticipant -> {
             ChatRoom chatRoom = loadChatRoomPort.findById(roomParticipant.roomId())

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomsService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomsService.java
@@ -1,0 +1,47 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lrchan.qootalk.application.chat.dto.command.ReadChatRoomsCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomsUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LoadChatRoomsService implements LoadChatRoomsUsecase {
+    
+    private final LoadChatRoomPort loadChatRoomPort;
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+    private final LoadMessagePort loadMessagePort;
+
+    @Override
+    public List<ChatRoomQueryResult> read(ReadChatRoomsCommand command) {
+        List<ChatRoom> chatRooms = loadChatRoomPort.findAllByUserId(command.userId(), command.page(), command.size());
+        return chatRooms.stream().map(chatRoom -> {
+            RoomParticipant roomParticipant = loadRoomParticipantPort.findByUserIdAndRoomId(command.userId(), chatRoom.id())
+                .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
+
+            Message lastMessage = loadMessagePort.findById(roomParticipant.lastReadMessageId())
+                .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID));
+
+            int unreadCount = (int) Math.min(999, loadMessagePort.countByRoomIdAndIdAfter(chatRoom.id(), roomParticipant.lastReadMessageId()));
+            ChatRoomQueryResult result = ChatRoomQueryResult.of(chatRoom, lastMessage, unreadCount);
+            return result;
+        }).toList();
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomsService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomsService.java
@@ -3,6 +3,7 @@ package com.lrchan.qootalk.application.chat.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +14,7 @@ import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
 import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.domain.chat.message.Message;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
@@ -25,23 +27,23 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class LoadChatRoomsService implements LoadChatRoomsUsecase {
     
-    private final LoadChatRoomPort loadChatRoomPort;
     private final LoadRoomParticipantPort loadRoomParticipantPort;
+    private final LoadChatRoomPort loadChatRoomPort;
     private final LoadMessagePort loadMessagePort;
 
     @Override
-    public List<ChatRoomQueryResult> read(ReadChatRoomsCommand command) {
-        List<ChatRoom> chatRooms = loadChatRoomPort.findAllByUserId(command.userId(), command.page(), command.size());
-        return chatRooms.stream().map(chatRoom -> {
-            RoomParticipant roomParticipant = loadRoomParticipantPort.findByUserIdAndRoomId(command.userId(), chatRoom.id())
-                .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
+    public PagedResponse<ChatRoomQueryResult> read(ReadChatRoomsCommand command) {
+        PagedResponse<RoomParticipant> roomParticipants = loadRoomParticipantPort.findPageByUserId(command.userId(), command.page(), command.size());
 
-            Message lastMessage = loadMessagePort.findById(roomParticipant.lastReadMessageId())
-                .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID));
+        return PagedResponse.of(roomParticipants.content().stream().map(roomParticipant -> {
+            ChatRoom chatRoom = loadChatRoomPort.findById(roomParticipant.roomId())
+                .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+            Message lastMessage = loadMessagePort.findById(roomParticipant.lastReadMessageId()).orElse(null);
 
             int unreadCount = (int) Math.min(999, loadMessagePort.countByRoomIdAndIdAfter(chatRoom.id(), roomParticipant.lastReadMessageId()));
-            ChatRoomQueryResult result = ChatRoomQueryResult.of(chatRoom, lastMessage, unreadCount);
-            return result;
-        }).toList();
+            
+            return ChatRoomQueryResult.of(chatRoom, lastMessage, unreadCount);
+        }).toList(), roomParticipants.page(), roomParticipants.size(), roomParticipants.totalElements(), roomParticipants.totalPages());
     }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomsService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomsService.java
@@ -1,38 +1,42 @@
 package com.lrchan.qootalk.application.chat.service;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.lrchan.qootalk.application.chat.dto.command.ReadChatRoomsCommand;
+import com.lrchan.qootalk.application.chat.dto.command.LoadChatRoomsCommand;
 import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomsUsecase;
 import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.domain.chat.message.Message;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class LoadChatRoomsService implements LoadChatRoomsUsecase {
     
+    private final LoadUserPort loadUserPort;
     private final LoadRoomParticipantPort loadRoomParticipantPort;
     private final LoadChatRoomPort loadChatRoomPort;
     private final LoadMessagePort loadMessagePort;
 
     @Override
-    public PagedResponse<ChatRoomQueryResult> read(ReadChatRoomsCommand command) {
+    public PagedResponse<ChatRoomQueryResult> load(LoadChatRoomsCommand command) {
+        // 유저 검증
+        loadUserPort.findById(command.userId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+            
+        // 채팅방 참여자 조회
         PagedResponse<RoomParticipant> roomParticipants = loadRoomParticipantPort.findPageByUserId(command.userId(), command.page(), command.size());
 
         return PagedResponse.of(roomParticipants.content().stream().map(roomParticipant -> {
@@ -42,7 +46,7 @@ public class LoadChatRoomsService implements LoadChatRoomsUsecase {
             Message lastMessage = loadMessagePort.findById(roomParticipant.lastReadMessageId()).orElse(null);
 
             int unreadCount = (int) Math.min(999, loadMessagePort.countByRoomIdAndIdAfter(chatRoom.id(), roomParticipant.lastReadMessageId()));
-            
+
             return ChatRoomQueryResult.of(chatRoom, lastMessage, unreadCount);
         }).toList(), roomParticipants.page(), roomParticipants.size(), roomParticipants.totalElements(), roomParticipants.totalPages());
     }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/UpdateChatRoomService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/UpdateChatRoomService.java
@@ -1,0 +1,50 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lrchan.qootalk.application.chat.dto.command.UpdateChatRoomCommand;
+import com.lrchan.qootalk.application.chat.dto.result.UpdateChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.UpdateChatRoomUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveChatRoomPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateChatRoomService implements UpdateChatRoomUsecase {
+
+    private final LoadUserPort loadUserPort;
+    private final LoadChatRoomPort loadChatRoomPort;
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+    private final SaveChatRoomPort saveChatRoomPort;
+
+    @Override
+    public UpdateChatRoomQueryResult update(UpdateChatRoomCommand command) {
+        // 유저 검증
+        loadUserPort.findById(command.requesterId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+
+        // 채팅방 검증
+        ChatRoom chatRoom = loadChatRoomPort.findById(command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 채팅방 참여자 검증
+        loadRoomParticipantPort.findByUserIdAndRoomId(command.requesterId(), command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
+
+        // 채팅방 수정
+        chatRoom.changeRoomName(command.roomName());
+        ChatRoom updatedChatRoom = saveChatRoomPort.save(chatRoom);
+        return UpdateChatRoomQueryResult.of(updatedChatRoom);
+    }
+    
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/ChatServiceTestFixtures.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/ChatServiceTestFixtures.java
@@ -1,0 +1,129 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+import com.lrchan.qootalk.domain.chat.vo.RoomName;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.UserRole;
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.Password;
+import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
+import com.lrchan.qootalk.domain.user.vo.StatusMessage;
+import com.lrchan.qootalk.domain.user.vo.UserName;
+
+final class ChatServiceTestFixtures {
+
+    private ChatServiceTestFixtures() {
+    }
+
+    static User activeUser(Long id) {
+        LocalDateTime now = LocalDateTime.now();
+        return User.reconstruct(
+            id,
+            new Email("user" + id + "@qootalk.com"),
+            new Password("encoded-password"),
+            new UserName("user" + id),
+            new ProfileImageUrl(null),
+            new StatusMessage(""),
+            UserRole.USER,
+            now.minusDays(1),
+            now.minusHours(1),
+            null
+        );
+    }
+
+    static User deletedUser(Long id) {
+        LocalDateTime now = LocalDateTime.now();
+        return User.reconstruct(
+            id,
+            new Email("deleted" + id + "@qootalk.com"),
+            new Password("encoded-password"),
+            new UserName("deleted" + id),
+            new ProfileImageUrl(null),
+            new StatusMessage(""),
+            UserRole.USER,
+            now.minusDays(2),
+            now.minusDays(1),
+            now
+        );
+    }
+
+    static ChatRoom activeRoom(Long id, Long createdBy) {
+        LocalDateTime now = LocalDateTime.now();
+        return ChatRoom.reconstruct(
+            id,
+            new RoomName("room-" + id),
+            RoomType.GROUP,
+            createdBy,
+            now.minusDays(1),
+            now.minusMinutes(10),
+            null
+        );
+    }
+
+    static ChatRoom deletedRoom(Long id, Long createdBy) {
+        LocalDateTime now = LocalDateTime.now();
+        return ChatRoom.reconstruct(
+            id,
+            new RoomName("room-" + id),
+            RoomType.GROUP,
+            createdBy,
+            now.minusDays(1),
+            now.minusMinutes(10),
+            now
+        );
+    }
+
+    static RoomParticipant participant(Long id, Long userId, Long roomId, Long lastReadMessageId, RoomRole role, boolean notificationEnabled) {
+        LocalDateTime now = LocalDateTime.now();
+        return RoomParticipant.reconstruct(
+            id,
+            userId,
+            roomId,
+            lastReadMessageId,
+            role,
+            notificationEnabled,
+            now.minusDays(1),
+            now.minusMinutes(5),
+            null
+        );
+    }
+
+    static RoomParticipant deletedParticipant(Long id, Long userId, Long roomId, Long lastReadMessageId, RoomRole role) {
+        LocalDateTime now = LocalDateTime.now();
+        return RoomParticipant.reconstruct(
+            id,
+            userId,
+            roomId,
+            lastReadMessageId,
+            role,
+            true,
+            now.minusDays(1),
+            now.minusMinutes(5),
+            now
+        );
+    }
+
+    static Message message(Long id, Long roomId, Long userId, String content, MessageType type) {
+        LocalDateTime now = LocalDateTime.now();
+        return Message.reconstruct(
+            id,
+            roomId,
+            userId,
+            content,
+            type,
+            List.of(),
+            null,
+            now.minusMinutes(1),
+            now.minusMinutes(1),
+            null
+        );
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/CreateChatRoomServiceTest.java
@@ -1,0 +1,104 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.CreateChatRoomCommand;
+import com.lrchan.qootalk.application.chat.dto.result.CreateChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.SaveChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class CreateChatRoomServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private SaveChatRoomPort saveChatRoomPort;
+    @Mock
+    private SaveRoomParticipantPort saveRoomParticipantPort;
+    @Mock
+    private SaveMessagePort saveMessagePort;
+
+    @InjectMocks
+    private CreateChatRoomService createChatRoomService;
+
+    @Test
+    @DisplayName("채팅방 생성에 성공하면 시스템 메시지와 참여자가 함께 저장된다")
+    void create_success() {
+        CreateChatRoomCommand command = new CreateChatRoomCommand(1L, "backend", RoomType.GROUP, List.of(2L, 3L), false);
+        User requester = ChatServiceTestFixtures.activeUser(1L);
+        User participant1 = ChatServiceTestFixtures.activeUser(2L);
+        User participant2 = ChatServiceTestFixtures.activeUser(3L);
+        ChatRoom savedRoom = ChatServiceTestFixtures.activeRoom(100L, 1L);
+        Message savedMessage = ChatServiceTestFixtures.message(200L, 100L, null, "채팅방을 생성했습니다.", MessageType.SYSTEM);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(requester));
+        given(loadUserPort.findById(2L)).willReturn(Optional.of(participant1));
+        given(loadUserPort.findById(3L)).willReturn(Optional.of(participant2));
+        given(saveChatRoomPort.save(any(ChatRoom.class))).willReturn(savedRoom);
+        given(saveMessagePort.save(any(Message.class))).willReturn(savedMessage);
+
+        CreateChatRoomQueryResult result = createChatRoomService.create(command);
+
+        assertThat(result.id()).isEqualTo(100L);
+        assertThat(result.createdBy()).isEqualTo(1L);
+        assertThat(result.participantCount()).isEqualTo(2);
+
+        ArgumentCaptor<RoomParticipant> participantCaptor = ArgumentCaptor.forClass(RoomParticipant.class);
+        verify(saveRoomParticipantPort, times(2)).save(participantCaptor.capture());
+        assertThat(participantCaptor.getAllValues())
+            .extracting(RoomParticipant::userId)
+            .containsExactly(2L, 3L);
+        assertThat(participantCaptor.getAllValues())
+            .allMatch(participant -> !participant.notificationEnabled());
+    }
+
+    @Test
+    @DisplayName("요청 사용자를 찾을 수 없으면 예외가 발생한다")
+    void create_fail_whenRequesterNotFound() {
+        CreateChatRoomCommand command = new CreateChatRoomCommand(1L, "backend", RoomType.GROUP, List.of(2L), true);
+        given(loadUserPort.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> createChatRoomService.create(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("삭제된 참여자가 포함되면 예외가 발생한다")
+    void create_fail_whenParticipantDeleted() {
+        CreateChatRoomCommand command = new CreateChatRoomCommand(1L, "backend", RoomType.GROUP, List.of(2L), true);
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadUserPort.findById(2L)).willReturn(Optional.of(ChatServiceTestFixtures.deletedUser(2L)));
+
+        assertThatThrownBy(() -> createChatRoomService.create(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(UserErrorCode.USER_DELETED.getMessage());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/DeleteChatRoomServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/DeleteChatRoomServiceTest.java
@@ -1,0 +1,89 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.DeleteChatRoomCommand;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteChatRoomServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadChatRoomPort loadChatRoomPort;
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+    @Mock
+    private SaveChatRoomPort saveChatRoomPort;
+    @Mock
+    private SaveRoomParticipantPort saveRoomParticipantPort;
+
+    @InjectMocks
+    private DeleteChatRoomService deleteChatRoomService;
+
+    @Test
+    @DisplayName("OWNER가 채팅방을 삭제하면 방과 참여자가 모두 삭제된다")
+    void delete_success() {
+        DeleteChatRoomCommand command = new DeleteChatRoomCommand(1L, 100L);
+        ChatRoom room = ChatServiceTestFixtures.activeRoom(100L, 1L);
+        RoomParticipant owner = ChatServiceTestFixtures.participant(1L, 1L, 100L, 200L, RoomRole.OWNER, true);
+        RoomParticipant member = ChatServiceTestFixtures.participant(2L, 2L, 100L, 200L, RoomRole.MEMBER, true);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(room));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L)).willReturn(Optional.of(owner));
+        given(loadRoomParticipantPort.findActiveByRoomId(100L)).willReturn(List.of(owner, member));
+
+        DeleteChatRoomQueryResult result = deleteChatRoomService.delete(command);
+
+        assertThat(result.id()).isEqualTo(100L);
+        assertThat(result.deletedAt()).isNotNull();
+        verify(saveChatRoomPort).save(room);
+
+        ArgumentCaptor<RoomParticipant> captor = ArgumentCaptor.forClass(RoomParticipant.class);
+        verify(saveRoomParticipantPort, times(2)).save(captor.capture());
+        assertThat(captor.getAllValues()).allMatch(RoomParticipant::isDeleted);
+    }
+
+    @Test
+    @DisplayName("권한이 없는 참여자는 채팅방을 삭제할 수 없다")
+    void delete_fail_whenInvalidRole() {
+        DeleteChatRoomCommand command = new DeleteChatRoomCommand(1L, 100L);
+        ChatRoom room = ChatServiceTestFixtures.activeRoom(100L, 1L);
+        RoomParticipant member = ChatServiceTestFixtures.participant(1L, 1L, 100L, 200L, RoomRole.MEMBER, true);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(room));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L)).willReturn(Optional.of(member));
+
+        assertThatThrownBy(() -> deleteChatRoomService.delete(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_ROOM_PARTICIPANT_INVALID_ROLE.getMessage());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomDetailServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomDetailServiceTest.java
@@ -1,0 +1,71 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.LoadChatRoomDetailCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomDetailQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+
+@ExtendWith(MockitoExtension.class)
+class LoadChatRoomDetailServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadChatRoomPort loadChatRoomPort;
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+
+    @InjectMocks
+    private LoadChatRoomDetailService loadChatRoomDetailService;
+
+    @Test
+    @DisplayName("채팅방 상세 조회에 성공하면 참여자 목록과 알림 설정을 반환한다")
+    void load_success() {
+        LoadChatRoomDetailCommand command = new LoadChatRoomDetailCommand(1L, 100L);
+        var requester = ChatServiceTestFixtures.participant(1L, 1L, 100L, 200L, RoomRole.OWNER, false);
+        var member = ChatServiceTestFixtures.participant(2L, 2L, 100L, 200L, RoomRole.MEMBER, true);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L)).willReturn(Optional.of(requester));
+        given(loadRoomParticipantPort.findActiveByRoomId(100L)).willReturn(List.of(requester, member));
+
+        ChatRoomDetailQueryResult result = loadChatRoomDetailService.load(command);
+
+        assertThat(result.id()).isEqualTo(100L);
+        assertThat(result.notificationEnabled()).isFalse();
+        assertThat(result.participants()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("참여자가 아니면 채팅방 상세 조회에 실패한다")
+    void load_fail_whenParticipantNotFound() {
+        LoadChatRoomDetailCommand command = new LoadChatRoomDetailCommand(1L, 100L);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> loadChatRoomDetailService.load(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND.getMessage());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomsServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/LoadChatRoomsServiceTest.java
@@ -1,0 +1,75 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.LoadChatRoomsCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.common.response.PagedResponse;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class LoadChatRoomsServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+    @Mock
+    private LoadChatRoomPort loadChatRoomPort;
+    @Mock
+    private LoadMessagePort loadMessagePort;
+
+    @InjectMocks
+    private LoadChatRoomsService loadChatRoomsService;
+
+    @Test
+    @DisplayName("채팅방 목록 조회에 성공하면 페이징 응답을 반환한다")
+    void load_success() {
+        LoadChatRoomsCommand command = new LoadChatRoomsCommand(1L, 0, 10);
+        RoomParticipant roomParticipant = ChatServiceTestFixtures.participant(1L, 1L, 100L, 200L, RoomRole.OWNER, true);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadRoomParticipantPort.findActivePageByUserId(1L, 0, 10))
+            .willReturn(PagedResponse.of(java.util.List.of(roomParticipant), 0, 10, 1, 1));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadMessagePort.findById(200L)).willReturn(Optional.of(ChatServiceTestFixtures.message(200L, 100L, 1L, "hello", MessageType.TEXT)));
+        given(loadMessagePort.countByRoomIdAndIdAfter(100L, 200L)).willReturn(3L);
+
+        PagedResponse<ChatRoomQueryResult> result = loadChatRoomsService.load(command);
+
+        assertThat(result.content()).hasSize(1);
+        assertThat(result.content().get(0).lastMessage()).isEqualTo("hello");
+        assertThat(result.content().get(0).unreadCount()).isEqualTo(3);
+        assertThat(result.totalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("사용자를 찾을 수 없으면 채팅방 목록 조회에 실패한다")
+    void load_fail_whenUserNotFound() {
+        LoadChatRoomsCommand command = new LoadChatRoomsCommand(1L, 0, 10);
+        given(loadUserPort.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> loadChatRoomsService.load(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/UpdateChatRoomServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/UpdateChatRoomServiceTest.java
@@ -1,0 +1,74 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.UpdateChatRoomCommand;
+import com.lrchan.qootalk.application.chat.dto.result.UpdateChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveChatRoomPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateChatRoomServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadChatRoomPort loadChatRoomPort;
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+    @Mock
+    private SaveChatRoomPort saveChatRoomPort;
+
+    @InjectMocks
+    private UpdateChatRoomService updateChatRoomService;
+
+    @Test
+    @DisplayName("채팅방 수정에 성공하면 변경된 이름이 반환된다")
+    void update_success() {
+        UpdateChatRoomCommand command = new UpdateChatRoomCommand(1L, 100L, "renamed-room");
+        ChatRoom room = ChatServiceTestFixtures.activeRoom(100L, 1L);
+        var participant = ChatServiceTestFixtures.participant(1L, 1L, 100L, 200L, RoomRole.OWNER, true);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(room));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L)).willReturn(Optional.of(participant));
+        given(saveChatRoomPort.save(any(ChatRoom.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateChatRoomQueryResult result = updateChatRoomService.update(command);
+
+        assertThat(result.id()).isEqualTo(100L);
+        assertThat(result.roomName()).isEqualTo("renamed-room");
+    }
+
+    @Test
+    @DisplayName("참여자가 아니면 채팅방 수정에 실패한다")
+    void update_fail_whenParticipantNotFound() {
+        UpdateChatRoomCommand command = new UpdateChatRoomCommand(1L, 100L, "renamed-room");
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> updateChatRoomService.update(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND.getMessage());
+    }
+}

--- a/qootalk-server/module-common/src/main/java/com/lrchan/qootalk/common/response/PagedResponse.java
+++ b/qootalk-server/module-common/src/main/java/com/lrchan/qootalk/common/response/PagedResponse.java
@@ -1,0 +1,15 @@
+package com.lrchan.qootalk.common.response;
+
+import java.util.List;
+
+public record PagedResponse<T>(
+    List<T> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages
+) {
+    public static <T> PagedResponse<T> of(List<T> content, int page, int size, long totalElements, int totalPages) {
+        return new PagedResponse<>(content, page, size, totalElements, totalPages);
+    }
+}

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
@@ -8,15 +8,16 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_ROOM_ALREADY_EXISTS("CHAT_002", "이미 존재하는 채팅방입니다.", 400),
     CHAT_ROOM_INVALID_NAME("CHAT_003", "채팅방 이름이 올바르지 않습니다.", 400),
     CHAT_ROOM_INVALID_TYPE("CHAT_004", "채팅방 타입이 올바르지 않습니다.", 400),
-    CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID("CHAT_005", "마지막 읽은 메시지 ID가 올바르지 않습니다.", 400),
+    CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID("CHAT_005", "마지막 읽은 메시지 ID가 올바르지 않습니다.", 404),
+    CHAT_ROOM_PARTICIPANT_NOT_FOUND("CHAT_006", "채팅방 참여자를 찾을 수 없습니다.", 404),
 
-    CHAT_FILE_METADATA_INVALID_STORAGE_TYPE("CHAT_006", "파일 메타데이터 스토리지 타입이 올바르지 않습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_FILE_NAME("CHAT_007", "파일 이름이 올바르지 않습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_CONTENT_TYPE("CHAT_008", "파일 메타데이터 콘텐츠 타입이 올바르지 않습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_FILE_SIZE("CHAT_009", "파일 크기가 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_STORAGE_TYPE("CHAT_007", "파일 메타데이터 스토리지 타입이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_FILE_NAME("CHAT_008", "파일 이름이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_CONTENT_TYPE("CHAT_009", "파일 메타데이터 콘텐츠 타입이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_FILE_SIZE("CHAT_010", "파일 크기가 올바르지 않습니다.", 400),
     CHAT_FILE_SECURITY_INVALID_MALICIOUS_FILE_DOWNLOADABLE_OR_SHAREABLE("CHAT_010", "악성 파일은 다운로드 및 공유가 불가능합니다.", 400),
-    CHAT_FILE_SECURITY_INVALID_PUBLIC_FILE_DOWNLOADABLE("CHAT_011", "공개 파일의 다운로드를 비활성화할 수 없습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_PATH("CHAT_012", "파일 경로가 올바르지 않습니다.", 400);
+    CHAT_FILE_SECURITY_INVALID_PUBLIC_FILE_DOWNLOADABLE("CHAT_012", "공개 파일의 다운로드를 비활성화할 수 없습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_PATH("CHAT_013", "파일 경로가 올바르지 않습니다.", 400);
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
@@ -12,14 +12,15 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID("CHAT_006", "마지막 읽은 메시지 ID가 올바르지 않습니다.", 404),
     CHAT_ROOM_PARTICIPANT_NOT_FOUND("CHAT_007", "채팅방 참여자를 찾을 수 없습니다.", 404),
     CHAT_ROOM_PARTICIPANT_DELETED("CHAT_008", "채팅방 참여자가 삭제되었습니다.", 404),
+    CHAT_ROOM_PARTICIPANT_INVALID_ROLE("CHAT_009", "채팅방 참여자 권한이 올바르지 않습니다.", 400),
 
-    CHAT_FILE_METADATA_INVALID_STORAGE_TYPE("CHAT_009", "파일 메타데이터 스토리지 타입이 올바르지 않습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_FILE_NAME("CHAT_010", "파일 이름이 올바르지 않습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_CONTENT_TYPE("CHAT_011", "파일 메타데이터 콘텐츠 타입이 올바르지 않습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_FILE_SIZE("CHAT_012", "파일 크기가 올바르지 않습니다.", 400),
-    CHAT_FILE_SECURITY_INVALID_MALICIOUS_FILE_DOWNLOADABLE_OR_SHAREABLE("CHAT_013", "악성 파일은 다운로드 및 공유가 불가능합니다.", 400),
-    CHAT_FILE_SECURITY_INVALID_PUBLIC_FILE_DOWNLOADABLE("CHAT_014", "공개 파일의 다운로드를 비활성화할 수 없습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_PATH("CHAT_015", "파일 경로가 올바르지 않습니다.", 400);
+    CHAT_FILE_METADATA_INVALID_STORAGE_TYPE("CHAT_010", "파일 메타데이터 스토리지 타입이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_FILE_NAME("CHAT_011", "파일 이름이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_CONTENT_TYPE("CHAT_012", "파일 메타데이터 콘텐츠 타입이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_FILE_SIZE("CHAT_013", "파일 크기가 올바르지 않습니다.", 400),
+    CHAT_FILE_SECURITY_INVALID_MALICIOUS_FILE_DOWNLOADABLE_OR_SHAREABLE("CHAT_014", "악성 파일은 다운로드 및 공유가 불가능합니다.", 400),
+    CHAT_FILE_SECURITY_INVALID_PUBLIC_FILE_DOWNLOADABLE("CHAT_015", "공개 파일의 다운로드를 비활성화할 수 없습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_PATH("CHAT_016", "파일 경로가 올바르지 않습니다.", 400);
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
@@ -5,19 +5,21 @@ import com.lrchan.qootalk.common.error.ErrorCode;
 public enum ChatErrorCode implements ErrorCode {
     
     CHAT_ROOM_NOT_FOUND("CHAT_001", "채팅방을 찾을 수 없습니다.", 404),
-    CHAT_ROOM_ALREADY_EXISTS("CHAT_002", "이미 존재하는 채팅방입니다.", 400),
-    CHAT_ROOM_INVALID_NAME("CHAT_003", "채팅방 이름이 올바르지 않습니다.", 400),
-    CHAT_ROOM_INVALID_TYPE("CHAT_004", "채팅방 타입이 올바르지 않습니다.", 400),
-    CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID("CHAT_005", "마지막 읽은 메시지 ID가 올바르지 않습니다.", 404),
-    CHAT_ROOM_PARTICIPANT_NOT_FOUND("CHAT_006", "채팅방 참여자를 찾을 수 없습니다.", 404),
+    CHAT_ROOM_DELETED("CHAT_002", "채팅방이 삭제되었습니다.", 404),
+    CHAT_ROOM_ALREADY_EXISTS("CHAT_003", "이미 존재하는 채팅방입니다.", 400),
+    CHAT_ROOM_INVALID_NAME("CHAT_004", "채팅방 이름이 올바르지 않습니다.", 400),
+    CHAT_ROOM_INVALID_TYPE("CHAT_005", "채팅방 타입이 올바르지 않습니다.", 400),
+    CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID("CHAT_006", "마지막 읽은 메시지 ID가 올바르지 않습니다.", 404),
+    CHAT_ROOM_PARTICIPANT_NOT_FOUND("CHAT_007", "채팅방 참여자를 찾을 수 없습니다.", 404),
+    CHAT_ROOM_PARTICIPANT_DELETED("CHAT_008", "채팅방 참여자가 삭제되었습니다.", 404),
 
-    CHAT_FILE_METADATA_INVALID_STORAGE_TYPE("CHAT_007", "파일 메타데이터 스토리지 타입이 올바르지 않습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_FILE_NAME("CHAT_008", "파일 이름이 올바르지 않습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_CONTENT_TYPE("CHAT_009", "파일 메타데이터 콘텐츠 타입이 올바르지 않습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_FILE_SIZE("CHAT_010", "파일 크기가 올바르지 않습니다.", 400),
-    CHAT_FILE_SECURITY_INVALID_MALICIOUS_FILE_DOWNLOADABLE_OR_SHAREABLE("CHAT_010", "악성 파일은 다운로드 및 공유가 불가능합니다.", 400),
-    CHAT_FILE_SECURITY_INVALID_PUBLIC_FILE_DOWNLOADABLE("CHAT_012", "공개 파일의 다운로드를 비활성화할 수 없습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_PATH("CHAT_013", "파일 경로가 올바르지 않습니다.", 400);
+    CHAT_FILE_METADATA_INVALID_STORAGE_TYPE("CHAT_009", "파일 메타데이터 스토리지 타입이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_FILE_NAME("CHAT_010", "파일 이름이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_CONTENT_TYPE("CHAT_011", "파일 메타데이터 콘텐츠 타입이 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_FILE_SIZE("CHAT_012", "파일 크기가 올바르지 않습니다.", 400),
+    CHAT_FILE_SECURITY_INVALID_MALICIOUS_FILE_DOWNLOADABLE_OR_SHAREABLE("CHAT_013", "악성 파일은 다운로드 및 공유가 불가능합니다.", 400),
+    CHAT_FILE_SECURITY_INVALID_PUBLIC_FILE_DOWNLOADABLE("CHAT_014", "공개 파일의 다운로드를 비활성화할 수 없습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_PATH("CHAT_015", "파일 경로가 올바르지 않습니다.", 400);
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/message/Message.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/message/Message.java
@@ -18,7 +18,7 @@ public class Message extends BaseModel {
             Long parentMessageId, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         super(id, createdAt, updatedAt, deletedAt);
         this.roomId = Objects.requireNonNull(roomId);
-        this.userId = Objects.requireNonNull(userId);
+        this.userId = userId;
         this.content = content;
         this.messageType = (messageType == null) ? MessageType.TEXT : messageType;
         this.mentions = mentions == null ? new ArrayList<>() : new ArrayList<>(mentions);

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipant.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipant.java
@@ -13,23 +13,34 @@ public class RoomParticipant extends BaseModel {
     private Long roomId;
     private Long lastReadMessageId;
     private RoomRole role;
+    private boolean notificationEnabled;
 
-    private RoomParticipant(Long id, Long userId, Long roomId, Long lastReadMessageId, RoomRole role, LocalDateTime createdAt,
-            LocalDateTime updatedAt, LocalDateTime deletedAt) {
+    private RoomParticipant(Long id, Long userId, Long roomId, Long lastReadMessageId, RoomRole role,
+            boolean notificationEnabled, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         super(id, createdAt, updatedAt, deletedAt);
         this.userId = Objects.requireNonNull(userId);
         this.roomId = Objects.requireNonNull(roomId);
         this.lastReadMessageId = Objects.requireNonNull(lastReadMessageId);
         this.role = role == null ? RoomRole.MEMBER : role;
+        this.notificationEnabled = notificationEnabled;
     }
 
     public static RoomParticipant create(Long userId, Long roomId, Long lastReadMessageId, RoomRole role) {
-        return new RoomParticipant(null, userId, roomId, lastReadMessageId, role, LocalDateTime.now(), LocalDateTime.now(), null);
+        return create(userId, roomId, lastReadMessageId, role, true);
+    }
+
+    public static RoomParticipant create(Long userId, Long roomId, Long lastReadMessageId, RoomRole role, boolean notificationEnabled) {
+        return new RoomParticipant(null, userId, roomId, lastReadMessageId, role, notificationEnabled, LocalDateTime.now(), LocalDateTime.now(), null);
     }
 
     // DB 복구 전용 메서드
     public static RoomParticipant reconstruct(Long id, Long userId, Long roomId, Long lastReadMessageId, RoomRole role, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
-        return new RoomParticipant(id, userId, roomId, lastReadMessageId, role, createdAt, updatedAt, deletedAt);
+        return reconstruct(id, userId, roomId, lastReadMessageId, role, true, createdAt, updatedAt, deletedAt);
+    }
+
+    public static RoomParticipant reconstruct(Long id, Long userId, Long roomId, Long lastReadMessageId, RoomRole role,
+            boolean notificationEnabled, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        return new RoomParticipant(id, userId, roomId, lastReadMessageId, role, notificationEnabled, createdAt, updatedAt, deletedAt);
     }   
 
     public Long userId() {
@@ -48,8 +59,17 @@ public class RoomParticipant extends BaseModel {
         return role;
     }
 
+    public boolean notificationEnabled() {
+        return notificationEnabled;
+    }
+
     public void changeRole(RoomRole role) {
         this.role = role == null ? RoomRole.MEMBER : role;
+        update();
+    }
+
+    public void changeNotificationEnabled(boolean notificationEnabled) {
+        this.notificationEnabled = notificationEnabled;
         update();
     }
 

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipant.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipant.java
@@ -80,4 +80,9 @@ public class RoomParticipant extends BaseModel {
         this.lastReadMessageId = messageId;
         update();
     }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+        update();
+    }
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipantRepository.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipantRepository.java
@@ -1,5 +1,6 @@
 package com.lrchan.qootalk.domain.chat.participant;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.lrchan.qootalk.common.response.PagedResponse;
@@ -8,5 +9,6 @@ public interface RoomParticipantRepository {
     Optional<RoomParticipant> findById(Long id);
     Optional<RoomParticipant> findByUserIdAndRoomId(Long userId, Long roomId);
     RoomParticipant save(RoomParticipant roomParticipant);
+    List<RoomParticipant> findActiveByRoomId(Long roomId);
     PagedResponse<RoomParticipant> findActivePageByUserId(Long userId, int page, int size);
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipantRepository.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipantRepository.java
@@ -8,5 +8,5 @@ public interface RoomParticipantRepository {
     Optional<RoomParticipant> findById(Long id);
     Optional<RoomParticipant> findByUserIdAndRoomId(Long userId, Long roomId);
     RoomParticipant save(RoomParticipant roomParticipant);
-    PagedResponse<RoomParticipant> findPageByUserId(Long userId, int page, int size);
+    PagedResponse<RoomParticipant> findActivePageByUserId(Long userId, int page, int size);
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipantRepository.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipantRepository.java
@@ -2,8 +2,11 @@ package com.lrchan.qootalk.domain.chat.participant;
 
 import java.util.Optional;
 
+import com.lrchan.qootalk.common.response.PagedResponse;
+
 public interface RoomParticipantRepository {
     Optional<RoomParticipant> findById(Long id);
     Optional<RoomParticipant> findByUserIdAndRoomId(Long userId, Long roomId);
     RoomParticipant save(RoomParticipant roomParticipant);
+    PagedResponse<RoomParticipant> findPageByUserId(Long userId, int page, int size);
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipantRepository.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipantRepository.java
@@ -4,5 +4,6 @@ import java.util.Optional;
 
 public interface RoomParticipantRepository {
     Optional<RoomParticipant> findById(Long id);
+    Optional<RoomParticipant> findByUserIdAndRoomId(Long userId, Long roomId);
     RoomParticipant save(RoomParticipant roomParticipant);
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/room/ChatRoom.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/room/ChatRoom.java
@@ -49,4 +49,9 @@ public class ChatRoom extends BaseModel {
         this.createdBy = createdBy;
         update();
     }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+        update();
+    }
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/room/ChatRoomRepository.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/room/ChatRoomRepository.java
@@ -1,5 +1,6 @@
 package com.lrchan.qootalk.domain.chat.room;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomRepository {
@@ -7,4 +8,5 @@ public interface ChatRoomRepository {
     Optional<ChatRoom> findByRoomName(String roomName);
     boolean existsByRoomName(String roomName);
     ChatRoom save(ChatRoom chatRoom);
+    List<ChatRoom> findAllByUserId(Long userId, int page, int size);
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/room/ChatRoomRepository.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/room/ChatRoomRepository.java
@@ -1,6 +1,5 @@
 package com.lrchan.qootalk.domain.chat.room;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomRepository {
@@ -8,5 +7,4 @@ public interface ChatRoomRepository {
     Optional<ChatRoom> findByRoomName(String roomName);
     boolean existsByRoomName(String roomName);
     ChatRoom save(ChatRoom chatRoom);
-    List<ChatRoom> findAllByUserId(Long userId, int page, int size);
 }

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/message/MessageTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/message/MessageTest.java
@@ -90,21 +90,6 @@ class MessageTest {
         }
 
         @Test
-        @DisplayName("userId가 null이면 예외가 발생해야 한다")
-        void should_ThrowException_When_UserIdIsNull() {
-            // given
-            Long roomId = 1L;
-            Long userId = null;
-            String content = "안녕하세요";
-            MessageType messageType = MessageType.TEXT;
-            List<Long> mentions = Collections.emptyList();
-
-            // when & then
-            assertThatThrownBy(() -> Message.create(roomId, userId, content, messageType, mentions))
-                .isInstanceOf(NullPointerException.class);
-        }
-
-        @Test
         @DisplayName("메시지를 생성할 때 멘션이 null이면 빈 리스트가 설정되어야 한다")
         void should_SetEmptyList_When_MentionsIsNull() {
             // given

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipantTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/participant/RoomParticipantTest.java
@@ -34,6 +34,7 @@ class RoomParticipantTest {
             assertThat(userChatRoom.roomId()).isEqualTo(100L);
             assertThat(userChatRoom.lastReadMessageId()).isEqualTo(0L);
             assertThat(userChatRoom.role()).isEqualTo(RoomRole.MEMBER);
+            assertThat(userChatRoom.notificationEnabled()).isTrue();
         }
 
         @Test
@@ -50,6 +51,21 @@ class RoomParticipantTest {
 
             // then
             assertThat(userChatRoom.role()).isEqualTo(RoomRole.MEMBER);
+        }
+
+        @Test
+        @DisplayName("유저 채팅방을 생성할 때 알림 설정을 지정할 수 있다")
+        void should_SetNotificationEnabled_When_CreateUserChatRoom() {
+            // given
+            Long userId = 1L;
+            Long roomId = 100L;
+            Long lastReadMessageId = 0L;
+
+            // when
+            RoomParticipant userChatRoom = RoomParticipant.create(userId, roomId, lastReadMessageId, RoomRole.MEMBER, false);
+
+            // then
+            assertThat(userChatRoom.notificationEnabled()).isFalse();
         }
 
         @Test
@@ -243,6 +259,19 @@ class RoomParticipantTest {
             // then
             assertThat(result).isEqualTo(RoomRole.MEMBER);
         }
+
+        @Test
+        @DisplayName("알림 사용 여부를 조회할 때 올바른 값이 반환되어야 한다")
+        void should_ReturnNotificationEnabled_When_GetNotificationEnabled() {
+            // given
+            RoomParticipant userChatRoom = RoomParticipant.create(1L, 100L, 0L, RoomRole.MEMBER, false);
+
+            // when
+            boolean result = userChatRoom.notificationEnabled();
+
+            // then
+            assertThat(result).isFalse();
+        }
     }
 
     @Nested
@@ -304,6 +333,24 @@ class RoomParticipantTest {
     }
 
     @Nested
+    @DisplayName("알림 설정 변경")
+    class ChangeNotificationEnabledTest {
+
+        @Test
+        @DisplayName("알림 설정을 변경할 수 있어야 한다")
+        void should_UpdateNotificationEnabled_When_Changed() {
+            // given
+            RoomParticipant userChatRoom = RoomParticipant.create(1L, 100L, 0L, RoomRole.MEMBER);
+
+            // when
+            userChatRoom.changeNotificationEnabled(false);
+
+            // then
+            assertThat(userChatRoom.notificationEnabled()).isFalse();
+        }
+    }
+
+    @Nested
     @DisplayName("소프트 삭제")
     class SoftDeleteTest {
 
@@ -325,4 +372,3 @@ class RoomParticipantTest {
         }
     }
 }
-

--- a/qootalk-server/module-infrastructure/build.gradle
+++ b/qootalk-server/module-infrastructure/build.gradle
@@ -52,3 +52,6 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3:2.41.13'
 }
 
+tasks.named('test') {
+	environment 'TESTCONTAINERS_RYUK_DISABLED', 'true'
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageEntity.java
@@ -1,9 +1,7 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.message;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageJpaRepository.java
@@ -1,6 +1,9 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.message;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MessageJpaRepository extends JpaRepository<MessageEntity, Long> {
+    @Query("SELECT COUNT(*) FROM MessageEntity WHERE roomId = :roomId AND id > :id")
+    Long countByRoomIdAndIdAfter(Long roomId, Long id);
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageRepositoryAdapter.java
@@ -4,11 +4,12 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
+import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
 import com.lrchan.qootalk.domain.chat.message.Message;
 import com.lrchan.qootalk.domain.chat.message.MessageRepository;
 
 @Component
-public class MessageRepositoryAdapter implements MessageRepository {
+public class MessageRepositoryAdapter implements MessageRepository, SaveMessagePort {
     private final MessageJpaRepository messageJpaRepository;
 
     public MessageRepositoryAdapter(MessageJpaRepository messageJpaRepository) {

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageRepositoryAdapter.java
@@ -4,12 +4,13 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
 import com.lrchan.qootalk.domain.chat.message.Message;
 import com.lrchan.qootalk.domain.chat.message.MessageRepository;
 
 @Component
-public class MessageRepositoryAdapter implements MessageRepository, SaveMessagePort {
+public class MessageRepositoryAdapter implements MessageRepository, SaveMessagePort, LoadMessagePort {
     private final MessageJpaRepository messageJpaRepository;
 
     public MessageRepositoryAdapter(MessageJpaRepository messageJpaRepository) {
@@ -26,5 +27,10 @@ public class MessageRepositoryAdapter implements MessageRepository, SaveMessageP
         MessageEntity messageEntity = MessageEntityMapper.toEntity(message);
         MessageEntity savedEntity = messageJpaRepository.save(messageEntity);
         return MessageEntityMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public Long countByRoomIdAndIdAfter(Long roomId, Long id) {
+        return messageJpaRepository.countByRoomIdAndIdAfter(roomId, id);
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantEntity.java
@@ -1,8 +1,5 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.participant;
 
-import java.time.LocalDateTime;
-import java.util.Objects;
-
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantEntity.java
@@ -40,4 +40,8 @@ public class RoomParticipantEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     private RoomRole role;
+
+    @Column(name = "notification_enabled", nullable = false)
+    @lombok.Builder.Default
+    private boolean notificationEnabled = true;
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantEntityMapper.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantEntityMapper.java
@@ -14,6 +14,7 @@ public class RoomParticipantEntityMapper {
             .roomId(roomParticipant.roomId())
             .lastReadMessageId(roomParticipant.lastReadMessageId())
             .role(roomParticipant.role())
+            .notificationEnabled(roomParticipant.notificationEnabled())
             .createdAt(roomParticipant.createdAt())
             .updatedAt(roomParticipant.updatedAt())
             .deletedAt(roomParticipant.deletedAt())
@@ -21,6 +22,16 @@ public class RoomParticipantEntityMapper {
     }
 
     public static RoomParticipant toDomain(RoomParticipantEntity roomParticipantEntity) {
-        return RoomParticipant.reconstruct(roomParticipantEntity.getId(), roomParticipantEntity.getUserId(), roomParticipantEntity.getRoomId(), roomParticipantEntity.getLastReadMessageId(), roomParticipantEntity.getRole(), roomParticipantEntity.getCreatedAt(), roomParticipantEntity.getUpdatedAt(), roomParticipantEntity.getDeletedAt());
+        return RoomParticipant.reconstruct(
+            roomParticipantEntity.getId(),
+            roomParticipantEntity.getUserId(),
+            roomParticipantEntity.getRoomId(),
+            roomParticipantEntity.getLastReadMessageId(),
+            roomParticipantEntity.getRole(),
+            roomParticipantEntity.isNotificationEnabled(),
+            roomParticipantEntity.getCreatedAt(),
+            roomParticipantEntity.getUpdatedAt(),
+            roomParticipantEntity.getDeletedAt()
+        );
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantJpaRepository.java
@@ -18,5 +18,5 @@ public interface RoomParticipantJpaRepository extends JpaRepository<RoomParticip
     @Query("SELECT rp FROM RoomParticipantEntity rp " +
        "WHERE rp.userId = :userId AND rp.deletedAt IS NULL " +
        "ORDER BY rp.lastReadMessageId DESC")
-    Page<RoomParticipantEntity> findPageByUserId(@Param("userId") Long userId, Pageable pageable);
+    Page<RoomParticipantEntity> findActivePageByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantJpaRepository.java
@@ -14,6 +14,9 @@ public interface RoomParticipantJpaRepository extends JpaRepository<RoomParticip
     boolean existsByUserIdAndRoomId(Long userId, Long roomId);
     List<RoomParticipantEntity> findByRoomId(Long roomId);
 
+    @Query("SELECT rp FROM RoomParticipantEntity rp " +
+       "WHERE rp.roomId = :roomId AND rp.deletedAt IS NULL ")
+    List<RoomParticipantEntity> findActiveByRoomId(@Param("roomId") Long roomId);
     
     @Query("SELECT rp FROM RoomParticipantEntity rp " +
        "WHERE rp.userId = :userId AND rp.deletedAt IS NULL " +

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantJpaRepository.java
@@ -3,10 +3,20 @@ package com.lrchan.qootalk.infrastructure.persistence.chat.participant;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoomParticipantJpaRepository extends JpaRepository<RoomParticipantEntity, Long> {
     Optional<RoomParticipantEntity> findByUserIdAndRoomId(Long userId, Long roomId);
     boolean existsByUserIdAndRoomId(Long userId, Long roomId);
     List<RoomParticipantEntity> findByRoomId(Long roomId);
+
+    
+    @Query("SELECT rp FROM RoomParticipantEntity rp " +
+       "WHERE rp.userId = :userId AND rp.deletedAt IS NULL " +
+       "ORDER BY rp.lastReadMessageId DESC")
+    Page<RoomParticipantEntity> findPageByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantJpaRepository.java
@@ -1,5 +1,6 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.participant;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RoomParticipantJpaRepository extends JpaRepository<RoomParticipantEntity, Long> {
     Optional<RoomParticipantEntity> findByUserIdAndRoomId(Long userId, Long roomId);
     boolean existsByUserIdAndRoomId(Long userId, Long roomId);
+    List<RoomParticipantEntity> findByRoomId(Long roomId);
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
@@ -34,4 +34,9 @@ public class RoomParticipantRepositoryAdapter implements RoomParticipantReposito
     public List<RoomParticipant> findByRoomId(Long roomId) {
         return roomParticipantJpaRepository.findByRoomId(roomId).stream().map(RoomParticipantEntityMapper::toDomain).toList();
     }
+
+    @Override
+    public Optional<RoomParticipant> findByUserIdAndRoomId(Long userId, Long roomId) {
+        return roomParticipantJpaRepository.findByUserIdAndRoomId(userId, roomId).map(RoomParticipantEntityMapper::toDomain);
+    }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
@@ -1,20 +1,22 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.participant;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipantRepository;
 
+import lombok.RequiredArgsConstructor;
+
 @Component
-public class RoomParticipantRepositoryAdapter implements RoomParticipantRepository {
+@RequiredArgsConstructor
+public class RoomParticipantRepositoryAdapter implements RoomParticipantRepository, LoadRoomParticipantPort, SaveRoomParticipantPort {
     
     private final RoomParticipantJpaRepository roomParticipantJpaRepository;
-
-    public RoomParticipantRepositoryAdapter(RoomParticipantJpaRepository roomParticipantJpaRepository) {
-        this.roomParticipantJpaRepository = roomParticipantJpaRepository;
-    }
 
     @Override
     public Optional<RoomParticipant> findById(Long id) {
@@ -26,5 +28,10 @@ public class RoomParticipantRepositoryAdapter implements RoomParticipantReposito
         RoomParticipantEntity roomParticipantEntity = RoomParticipantEntityMapper.toEntity(roomParticipant);
         RoomParticipantEntity savedEntity = roomParticipantJpaRepository.save(roomParticipantEntity);
         return RoomParticipantEntityMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public List<RoomParticipant> findByRoomId(Long roomId) {
+        return roomParticipantJpaRepository.findByRoomId(roomId).stream().map(RoomParticipantEntityMapper::toDomain).toList();
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
@@ -3,10 +3,15 @@ package com.lrchan.qootalk.infrastructure.persistence.chat.participant;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
 import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
+import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipantRepository;
 
@@ -38,5 +43,13 @@ public class RoomParticipantRepositoryAdapter implements RoomParticipantReposito
     @Override
     public Optional<RoomParticipant> findByUserIdAndRoomId(Long userId, Long roomId) {
         return roomParticipantJpaRepository.findByUserIdAndRoomId(userId, roomId).map(RoomParticipantEntityMapper::toDomain);
+    }
+
+    @Override
+    public PagedResponse<RoomParticipant> findPageByUserId(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<RoomParticipantEntity> roomParticipantEntities = roomParticipantJpaRepository.findPageByUserId(userId, pageable);
+
+        return PagedResponse.of(roomParticipantEntities.getContent().stream().map(RoomParticipantEntityMapper::toDomain).toList(), roomParticipantEntities.getNumber(), roomParticipantEntities.getSize(), roomParticipantEntities.getTotalElements(), roomParticipantEntities.getTotalPages());
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
@@ -45,9 +45,9 @@ public class RoomParticipantRepositoryAdapter implements RoomParticipantReposito
     }
 
     @Override
-    public PagedResponse<RoomParticipant> findPageByUserId(Long userId, int page, int size) {
+    public PagedResponse<RoomParticipant> findActivePageByUserId(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<RoomParticipantEntity> roomParticipantEntities = roomParticipantJpaRepository.findPageByUserId(userId, pageable);
+        Page<RoomParticipantEntity> roomParticipantEntities = roomParticipantJpaRepository.findActivePageByUserId(userId, pageable);
 
         return PagedResponse.of(roomParticipantEntities.getContent().stream().map(RoomParticipantEntityMapper::toDomain).toList(), roomParticipantEntities.getNumber(), roomParticipantEntities.getSize(), roomParticipantEntities.getTotalElements(), roomParticipantEntities.getTotalPages());
     }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
@@ -45,6 +45,11 @@ public class RoomParticipantRepositoryAdapter implements RoomParticipantReposito
     }
 
     @Override
+    public List<RoomParticipant> findActiveByRoomId(Long roomId) {
+        return roomParticipantJpaRepository.findActiveByRoomId(roomId).stream().map(RoomParticipantEntityMapper::toDomain).toList();
+    }
+    
+    @Override
     public PagedResponse<RoomParticipant> findActivePageByUserId(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<RoomParticipantEntity> roomParticipantEntities = roomParticipantJpaRepository.findActivePageByUserId(userId, pageable);

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomJpaRepository.java
@@ -2,12 +2,9 @@ package com.lrchan.qootalk.infrastructure.persistence.chat.room;
 
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomEntity, Long> {
     Optional<ChatRoomEntity> findByRoomName(String roomName);
     boolean existsByRoomName(String roomName);
-    Page<ChatRoomEntity> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomJpaRepository.java
@@ -2,9 +2,12 @@ package com.lrchan.qootalk.infrastructure.persistence.chat.room;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomEntity, Long> {
     Optional<ChatRoomEntity> findByRoomName(String roomName);
     boolean existsByRoomName(String roomName);
+    Page<ChatRoomEntity> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomRepositoryAdapter.java
@@ -1,14 +1,19 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.room;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import com.lrchan.qootalk.application.chat.port.out.ReadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveChatRoomPort;
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
 import com.lrchan.qootalk.domain.chat.room.ChatRoomRepository;
 
 @Component
-public class ChatRoomRepositoryAdapter implements ChatRoomRepository {
+public class ChatRoomRepositoryAdapter implements ChatRoomRepository, SaveChatRoomPort, ReadChatRoomPort {
     
     private final ChatRoomJpaRepository chatRoomJpaRepository;
     
@@ -36,5 +41,11 @@ public class ChatRoomRepositoryAdapter implements ChatRoomRepository {
         ChatRoomEntity chatRoomEntity = ChatRoomEntityMapper.toEntity(chatRoom);
         ChatRoomEntity savedEntity = chatRoomJpaRepository.save(chatRoomEntity);
         return ChatRoomEntityMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public List<ChatRoom> findAllByUserId(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return chatRoomJpaRepository.findAllByUserId(userId, pageable).stream().map(ChatRoomEntityMapper::toDomain).toList();
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomRepositoryAdapter.java
@@ -7,13 +7,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
-import com.lrchan.qootalk.application.chat.port.out.ReadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
 import com.lrchan.qootalk.application.chat.port.out.SaveChatRoomPort;
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
 import com.lrchan.qootalk.domain.chat.room.ChatRoomRepository;
 
 @Component
-public class ChatRoomRepositoryAdapter implements ChatRoomRepository, SaveChatRoomPort, ReadChatRoomPort {
+public class ChatRoomRepositoryAdapter implements ChatRoomRepository, SaveChatRoomPort, LoadChatRoomPort {
     
     private final ChatRoomJpaRepository chatRoomJpaRepository;
     
@@ -41,11 +41,5 @@ public class ChatRoomRepositoryAdapter implements ChatRoomRepository, SaveChatRo
         ChatRoomEntity chatRoomEntity = ChatRoomEntityMapper.toEntity(chatRoom);
         ChatRoomEntity savedEntity = chatRoomJpaRepository.save(chatRoomEntity);
         return ChatRoomEntityMapper.toDomain(savedEntity);
-    }
-
-    @Override
-    public List<ChatRoom> findAllByUserId(Long userId, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        return chatRoomJpaRepository.findAllByUserId(userId, pageable).stream().map(ChatRoomEntityMapper::toDomain).toList();
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_3__room_participants.sql
+++ b/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_3__room_participants.sql
@@ -5,6 +5,7 @@ create table room_participants (
   room_id bigint not null,
   last_read_message_id bigint not null,
   role varchar(255) not null,
+  notification_enabled boolean not null default true,
   created_at timestamp not null,
   updated_at timestamp not null,
   deleted_at timestamp

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantEntityMapperTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantEntityMapperTest.java
@@ -30,6 +30,7 @@ class RoomParticipantEntityMapperTest {
                 .roomId(20L)
                 .lastReadMessageId(30L)
                 .role(RoomRole.ADMIN)
+                .notificationEnabled(false)
                 .createdAt(now)
                 .updatedAt(now)
                 .deletedAt(deletedAt)
@@ -44,6 +45,7 @@ class RoomParticipantEntityMapperTest {
             assertThat(domain.roomId()).isEqualTo(20L);
             assertThat(domain.lastReadMessageId()).isEqualTo(30L);
             assertThat(domain.role()).isEqualTo(RoomRole.ADMIN);
+            assertThat(domain.notificationEnabled()).isFalse();
             assertThat(domain.createdAt()).isEqualTo(now);
             assertThat(domain.updatedAt()).isEqualTo(now);
             assertThat(domain.deletedAt()).isEqualTo(deletedAt);
@@ -61,6 +63,7 @@ class RoomParticipantEntityMapperTest {
                 .roomId(20L)
                 .lastReadMessageId(30L)
                 .role(null)
+                .notificationEnabled(true)
                 .createdAt(now)
                 .updatedAt(now)
                 .deletedAt(null)
@@ -91,6 +94,7 @@ class RoomParticipantEntityMapperTest {
                 20L,
                 30L,
                 RoomRole.OWNER,
+                false,
                 now,
                 now,
                 null
@@ -105,6 +109,7 @@ class RoomParticipantEntityMapperTest {
             assertThat(entity.getRoomId()).isEqualTo(20L);
             assertThat(entity.getLastReadMessageId()).isEqualTo(30L);
             assertThat(entity.getRole()).isEqualTo(RoomRole.OWNER);
+            assertThat(entity.isNotificationEnabled()).isFalse();
         }
 
         @Test
@@ -118,6 +123,7 @@ class RoomParticipantEntityMapperTest {
                 20L,
                 30L,
                 null,
+                true,
                 now,
                 now,
                 null
@@ -128,6 +134,7 @@ class RoomParticipantEntityMapperTest {
 
             // then
             assertThat(entity.getRole()).isEqualTo(RoomRole.MEMBER);
+            assertThat(entity.isNotificationEnabled()).isTrue();
         }
     }
 
@@ -146,6 +153,7 @@ class RoomParticipantEntityMapperTest {
                 20L,
                 30L,
                 RoomRole.ADMIN,
+                false,
                 now,
                 now,
                 null
@@ -160,7 +168,7 @@ class RoomParticipantEntityMapperTest {
             assertThat(converted.roomId()).isEqualTo(original.roomId());
             assertThat(converted.lastReadMessageId()).isEqualTo(original.lastReadMessageId());
             assertThat(converted.role()).isEqualTo(original.role());
+            assertThat(converted.notificationEnabled()).isEqualTo(original.notificationEnabled());
         }
     }
 }
-

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantJpaRepositoryTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantJpaRepositoryTest.java
@@ -26,6 +26,7 @@ public class RoomParticipantJpaRepositoryTest extends IntegrationTestSupport {
             .roomId(10L)
             .lastReadMessageId(100L)
             .role(RoomRole.MEMBER)
+            .notificationEnabled(false)
             .build();
 
         // when
@@ -37,6 +38,7 @@ public class RoomParticipantJpaRepositoryTest extends IntegrationTestSupport {
         assertThat(savedEntity.getRoomId()).isEqualTo(10L);
         assertThat(savedEntity.getLastReadMessageId()).isEqualTo(100L);
         assertThat(savedEntity.getRole()).isEqualTo(RoomRole.MEMBER);
+        assertThat(savedEntity.isNotificationEnabled()).isFalse();
         assertThat(savedEntity.getCreatedAt()).isNotNull();
         assertThat(savedEntity.getUpdatedAt()).isNotNull();
     }
@@ -53,6 +55,7 @@ public class RoomParticipantJpaRepositoryTest extends IntegrationTestSupport {
                 .roomId(10L)
                 .lastReadMessageId(100L)
                 .role(RoomRole.MEMBER)
+                .notificationEnabled(true)
                 .build();
             roomParticipantJpaRepository.save(participantEntity);
 
@@ -67,6 +70,7 @@ public class RoomParticipantJpaRepositoryTest extends IntegrationTestSupport {
             assertThat(foundEntity.getRoomId()).isEqualTo(10L);
             assertThat(foundEntity.getLastReadMessageId()).isEqualTo(100L);
             assertThat(foundEntity.getRole()).isEqualTo(RoomRole.MEMBER);
+            assertThat(foundEntity.isNotificationEnabled()).isTrue();
         }
 
         @Test
@@ -89,6 +93,7 @@ public class RoomParticipantJpaRepositoryTest extends IntegrationTestSupport {
                 .roomId(10L)
                 .lastReadMessageId(100L)
                 .role(RoomRole.MEMBER)
+                .notificationEnabled(true)
                 .build();
             roomParticipantJpaRepository.save(participantEntity);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #78 
## 📝작업 내용
- **채팅방 생성, 수정, 삭제 기능 구현**: 
  - `CreateChatRoomService`, `UpdateChatRoomService`, `DeleteChatRoomService`를 통해 각 기능의 비즈니스 로직을 구현
- **채팅방 상세 조회 및 목록 조회 기능 추가**:
  - `LoadChatRoomDetailService`와 `LoadChatRoomsService`를 통해 해당 기능의 로직을 구현
- **유저 검증 및 페이지네이션 기능 개선**:
  - 채팅방 관련 usecase에 유저 검증 및 삭제 검증 로직을 추가하여 강화하였습니다.
  - `PagedResponse`를 정의하여 페이지네이션 결과를 설계
  - LastMessageId 필드에 대해 reverseOrder() 페이지네이션으로 구현하였습니다.