### PR TITLE
feat: 채팅 파일 첨부 기능 및 서비스 추가

### DIFF
--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/DeleteFileAttachmentCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/DeleteFileAttachmentCommand.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+public record DeleteFileAttachmentCommand(
+    Long requesterId,
+    Long roomId,
+    Long fileAttachmentId
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/LoadFileAttachmentsCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/LoadFileAttachmentsCommand.java
@@ -1,9 +1,12 @@
 package com.lrchan.qootalk.application.chat.dto.command;
 
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
+
 public record LoadFileAttachmentsCommand(
     Long requesterId,
     Long roomId,
     Long uploaderId,
+    FileType fileType,
     int page,
     int size
 ) {

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/LoadFileAttachmentsCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/LoadFileAttachmentsCommand.java
@@ -1,0 +1,10 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+public record LoadFileAttachmentsCommand(
+    Long requesterId,
+    Long roomId,
+    Long uploaderId,
+    int page,
+    int size
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/SendMessageCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/SendMessageCommand.java
@@ -1,0 +1,16 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+import java.util.List;
+
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+
+public record SendMessageCommand(
+    Long requesterId,
+    Long roomId,
+    String content,
+    MessageType messageType,
+    List<Long> mentions,
+    Long parentMessageId,
+    List<Long> attachmentIds
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/UploadFileAttachmentCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/UploadFileAttachmentCommand.java
@@ -1,0 +1,13 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+import java.io.InputStream;
+
+public record UploadFileAttachmentCommand(
+    Long requesterId,
+    Long roomId,
+    InputStream inputStream,
+    String originalFileName,
+    String contentType,
+    long fileSize
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/UploadFileAttachmentCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/UploadFileAttachmentCommand.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 public record UploadFileAttachmentCommand(
     Long requesterId,
     Long roomId,
+    Long messageId,
     InputStream inputStream,
     String originalFileName,
     String contentType,

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/DeleteFileAttachmentQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/DeleteFileAttachmentQueryResult.java
@@ -1,0 +1,17 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+
+public record DeleteFileAttachmentQueryResult(
+    Long id,
+    LocalDateTime deletedAt
+) {
+    public static DeleteFileAttachmentQueryResult of(FileAttachment fileAttachment) {
+        return new DeleteFileAttachmentQueryResult(
+            fileAttachment.id(),
+            fileAttachment.deletedAt()
+        );
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/FileAttachmentQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/FileAttachmentQueryResult.java
@@ -1,6 +1,14 @@
 package com.lrchan.qootalk.application.chat.dto.result;
 
+import java.time.LocalDateTime;
+
 import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
+import com.lrchan.qootalk.domain.chat.vo.ContentType;
+import com.lrchan.qootalk.domain.chat.vo.FileName;
+import com.lrchan.qootalk.domain.chat.vo.FileSize;
+import com.lrchan.qootalk.domain.chat.vo.Path;
+import com.lrchan.qootalk.domain.chat.vo.StorageType;
 
 import lombok.Builder;
 
@@ -9,18 +17,26 @@ public record FileAttachmentQueryResult(
     Long id,
     Long messageId,
     Long uploaderId,
-    String fileName,
-    String contentType,
-    long fileSize
+    FileName fileName,
+    FileType fileType,
+    ContentType contentType,
+    FileSize fileSize,
+    StorageType storageType,
+    Path storagePath,
+    LocalDateTime createdAt
 ) {
     public static FileAttachmentQueryResult of(FileAttachment fileAttachment) {
-        return new FileAttachmentQueryResult(
-            fileAttachment.id(),
-            fileAttachment.messageId(),
-            fileAttachment.uploaderId(),
-            fileAttachment.metadata().originalFileName().value(),
-            fileAttachment.metadata().contentType().value(),
-            fileAttachment.metadata().fileSize().value()
-        );
+        return FileAttachmentQueryResult.builder()
+            .id(fileAttachment.id())
+            .messageId(fileAttachment.messageId())
+            .uploaderId(fileAttachment.uploaderId())
+            .fileName(fileAttachment.metadata().originalFileName())
+            .fileType(fileAttachment.fileType())
+            .contentType(fileAttachment.metadata().contentType())
+            .fileSize(fileAttachment.metadata().fileSize())
+            .storageType(fileAttachment.metadata().storageType())
+            .storagePath(fileAttachment.metadata().storagePath())
+            .createdAt(fileAttachment.createdAt())
+            .build();
     }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/FileAttachmentQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/FileAttachmentQueryResult.java
@@ -1,0 +1,26 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+
+import lombok.Builder;
+
+@Builder
+public record FileAttachmentQueryResult(
+    Long id,
+    Long messageId,
+    Long uploaderId,
+    String fileName,
+    String contentType,
+    long fileSize
+) {
+    public static FileAttachmentQueryResult of(FileAttachment fileAttachment) {
+        return new FileAttachmentQueryResult(
+            fileAttachment.id(),
+            fileAttachment.messageId(),
+            fileAttachment.uploaderId(),
+            fileAttachment.metadata().originalFileName().value(),
+            fileAttachment.metadata().contentType().value(),
+            fileAttachment.metadata().fileSize().value()
+        );
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/SendMessageQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/SendMessageQueryResult.java
@@ -1,0 +1,19 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+
+public record SendMessageQueryResult(
+    Long id,
+    Long roomId,
+    Long senderId,
+    String content,
+    MessageType messageType,
+    List<Long> mentions,
+    Long parentMessageId,
+    List<Long> attachmentIds,
+    LocalDateTime createdAt
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/DeleteFileAttachmentUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/DeleteFileAttachmentUsecase.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.command.DeleteFileAttachmentCommand;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteFileAttachmentQueryResult;
+
+public interface DeleteFileAttachmentUsecase {
+    DeleteFileAttachmentQueryResult delete(DeleteFileAttachmentCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadFileAttachmentsUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadFileAttachmentsUsecase.java
@@ -1,0 +1,9 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.command.LoadFileAttachmentsCommand;
+import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
+import com.lrchan.qootalk.common.response.PagedResponse;
+
+public interface LoadFileAttachmentsUsecase {
+    PagedResponse<FileAttachmentQueryResult> load(LoadFileAttachmentsCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/UploadFileAttachmentUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/UploadFileAttachmentUsecase.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.command.UploadFileAttachmentCommand;
+import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
+
+public interface UploadFileAttachmentUsecase {
+    FileAttachmentQueryResult upload(UploadFileAttachmentCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/DeleteFileAttachmentPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/DeleteFileAttachmentPort.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+
+public interface DeleteFileAttachmentPort {
+    FileAttachment delete(FileAttachment fileAttachmentId);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadFileAttachmentPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadFileAttachmentPort.java
@@ -1,0 +1,9 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import com.lrchan.qootalk.common.response.PagedResponse;
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
+
+public interface LoadFileAttachmentPort {
+    PagedResponse<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(Long roomId, Long uploaderId, FileType fileType, int page, int size);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadFileAttachmentPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadFileAttachmentPort.java
@@ -1,10 +1,13 @@
 package com.lrchan.qootalk.application.chat.port.out;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 
 import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
 import com.lrchan.qootalk.domain.chat.attachment.FileType;
 
 public interface LoadFileAttachmentPort {
+    Optional<FileAttachment> findById(Long id);
     Page<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(Long roomId, Long uploaderId, FileType fileType, int page, int size);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadFileAttachmentPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadFileAttachmentPort.java
@@ -1,9 +1,10 @@
 package com.lrchan.qootalk.application.chat.port.out;
 
-import com.lrchan.qootalk.common.response.PagedResponse;
+import org.springframework.data.domain.Page;
+
 import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
 import com.lrchan.qootalk.domain.chat.attachment.FileType;
 
 public interface LoadFileAttachmentPort {
-    PagedResponse<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(Long roomId, Long uploaderId, FileType fileType, int page, int size);
+    Page<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(Long roomId, Long uploaderId, FileType fileType, int page, int size);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/SaveFileAttachmentPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/SaveFileAttachmentPort.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+
+public interface SaveFileAttachmentPort {
+    FileAttachment save(FileAttachment fileAttachment);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/DeleteFileAttachmentService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/DeleteFileAttachmentService.java
@@ -1,8 +1,12 @@
 package com.lrchan.qootalk.application.chat.service;
 
-import com.lrchan.qootalk.application.chat.dto.command.LoadFileAttachmentsCommand;
-import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
-import com.lrchan.qootalk.application.chat.port.in.LoadFileAttachmentsUsecase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lrchan.qootalk.application.chat.dto.command.DeleteFileAttachmentCommand;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteFileAttachmentQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.DeleteFileAttachmentUsecase;
+import com.lrchan.qootalk.application.chat.port.out.DeleteFileAttachmentPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
@@ -11,36 +15,34 @@ import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
 import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
 import com.lrchan.qootalk.domain.user.User;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
-import com.lrchan.qootalk.common.response.PagedResponse;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-@Service  
+@Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class LoadFileAttachmentsService implements LoadFileAttachmentsUsecase {
-
+@Transactional
+public class DeleteFileAttachmentService implements DeleteFileAttachmentUsecase {
+    
     private final LoadUserPort loadUserPort;
     private final LoadChatRoomPort loadChatRoomPort;
-    private final LoadFileAttachmentPort loadFileAttachmentPort;
     private final LoadRoomParticipantPort loadRoomParticipantPort;
-    
+    private final LoadFileAttachmentPort loadFileAttachmentPort;
+    private final DeleteFileAttachmentPort deleteFileAttachmentPort;
+
     @Override
-    public PagedResponse<FileAttachmentQueryResult> load(LoadFileAttachmentsCommand command) {
-        // 유저 검증
+    public DeleteFileAttachmentQueryResult delete(DeleteFileAttachmentCommand command) {
+        
+        // 사용자 검증
         User user = loadUserPort.findById(command.requesterId())
             .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
         if (user.deletedAt() != null) {
             throw new DomainException(UserErrorCode.USER_DELETED);
         }
-        
+
         // 채팅방 검증
         ChatRoom chatRoom = loadChatRoomPort.findById(command.roomId())
             .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
@@ -48,16 +50,28 @@ public class LoadFileAttachmentsService implements LoadFileAttachmentsUsecase {
             throw new DomainException(ChatErrorCode.CHAT_ROOM_DELETED);
         }
         
-        // 채팅방 참여자 검증
+        // 채팅방 사용자 검증
         RoomParticipant roomParticipant = loadRoomParticipantPort.findByUserIdAndRoomId(command.requesterId(), command.roomId())
             .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
         if (roomParticipant.deletedAt() != null) {
             throw new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_DELETED);
         }
-        
-        // 파일 조회
-        Page<FileAttachment> fileAttachments = loadFileAttachmentPort.findPageByRoomIdAndUploaderIdAndFileType(command.roomId(), command.uploaderId(), command.fileType(), command.page(), command.size());
-        
-        return PagedResponse.of(fileAttachments.map(FileAttachmentQueryResult::of).toList(), fileAttachments.getNumber(), fileAttachments.getSize(), fileAttachments.getTotalElements(), fileAttachments.getTotalPages());
+
+        // 파일 첨부파일 검증
+        FileAttachment fileAttachment = loadFileAttachmentPort.findById(command.fileAttachmentId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_FILE_ATTACHMENT_NOT_FOUND));
+        if (fileAttachment.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_FILE_ATTACHMENT_DELETED);
+        }
+
+        // 권한 검증(Uploader, Owner, or Admin)
+        if (!roomParticipant.role().equals(RoomRole.OWNER) && !roomParticipant.role().equals(RoomRole.ADMIN) && !fileAttachment.uploaderId().equals(roomParticipant.userId())) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_INVALID_ROLE);
+        }
+
+        // 파일 첨부파일 삭제
+        FileAttachment deletedFileAttachment = deleteFileAttachmentPort.delete(fileAttachment);
+
+        return DeleteFileAttachmentQueryResult.of(deletedFileAttachment);
     }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadFileAttachmentsService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadFileAttachmentsService.java
@@ -8,11 +8,14 @@ import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
 import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
 import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
 import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
 import com.lrchan.qootalk.common.response.PagedResponse;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +39,13 @@ public class LoadFileAttachmentsService implements LoadFileAttachmentsUsecase {
         loadChatRoomPort.findById(command.roomId())
             .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
         
+        // 채팅방 참여자 검증
+        loadRoomParticipantPort.findByUserIdAndRoomId(command.requesterId(), command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
         
-        return null;
+        // 파일 조회
+        Page<FileAttachment> fileAttachments = loadFileAttachmentPort.findPageByRoomIdAndUploaderIdAndFileType(command.roomId(), command.uploaderId(), command.fileType(), command.page(), command.size());
+        
+        return PagedResponse.of(fileAttachments.map(FileAttachmentQueryResult::of).toList(), fileAttachments.getNumber(), fileAttachments.getSize(), fileAttachments.getTotalElements(), fileAttachments.getTotalPages());
     }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadFileAttachmentsService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadFileAttachmentsService.java
@@ -1,0 +1,42 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import com.lrchan.qootalk.application.chat.dto.command.LoadFileAttachmentsCommand;
+import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.LoadFileAttachmentsUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+import com.lrchan.qootalk.common.response.PagedResponse;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service  
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoadFileAttachmentsService implements LoadFileAttachmentsUsecase {
+
+    private final LoadUserPort loadUserPort;
+    private final LoadChatRoomPort loadChatRoomPort;
+    private final LoadFileAttachmentPort loadFileAttachmentPort;
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+    
+    @Override
+    public PagedResponse<FileAttachmentQueryResult> load(LoadFileAttachmentsCommand command) {
+        // 유저 검증
+        loadUserPort.findById(command.requesterId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        
+        // 채팅방 검증
+        loadChatRoomPort.findById(command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        
+        
+        return null;
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/UploadFileAttachmentService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/UploadFileAttachmentService.java
@@ -1,0 +1,90 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lrchan.qootalk.application.chat.dto.command.UploadFileAttachmentCommand;
+import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.UploadFileAttachmentUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveFileAttachmentPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.application.user.port.out.UploadFilePort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.common.storage.vo.StorageResource;
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.chat.vo.ContentType;
+import com.lrchan.qootalk.domain.chat.vo.FileMetadata;
+import com.lrchan.qootalk.domain.chat.vo.FileName;
+import com.lrchan.qootalk.domain.chat.vo.FileSecurity;
+import com.lrchan.qootalk.domain.chat.vo.Path;
+import com.lrchan.qootalk.domain.chat.vo.StorageType;
+import com.lrchan.qootalk.domain.chat.vo.FileSize;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UploadFileAttachmentService implements UploadFileAttachmentUsecase {
+
+    private final LoadUserPort loadUserPort;
+    private final LoadChatRoomPort loadChatRoomPort;
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+    private final UploadFilePort uploadFilePort;
+    private final SaveFileAttachmentPort saveFileAttachmentPort;
+
+    @Override
+    public FileAttachmentQueryResult upload(UploadFileAttachmentCommand command) {
+        // 유저 검증
+        User user = loadUserPort.findById(command.requesterId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.deletedAt() != null) {
+            throw new DomainException(UserErrorCode.USER_DELETED);
+        }
+
+        // 채팅방 검증
+        ChatRoom chatRoom = loadChatRoomPort.findById(command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (chatRoom.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_DELETED);
+        }
+        
+        // 채팅방 참여자 검증
+        RoomParticipant roomParticipant = loadRoomParticipantPort.findByUserIdAndRoomId(command.requesterId(), command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
+        if (roomParticipant.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_DELETED);
+        }
+
+        // 파일 업로드
+        String path = "chat/" + command.roomId() + "/attachments/" + command.messageId() + "/";
+        StorageResource resource = new StorageResource(
+            path,
+            command.originalFileName(),
+            command.contentType(),
+            command.fileSize());
+        String uri = uploadFilePort.upload(command.inputStream(), resource);
+
+        // 파일 저장
+        FileMetadata metadata = new FileMetadata(
+            new FileName(command.originalFileName()),
+            new FileName(uri.substring(uri.lastIndexOf('/') + 1)),
+            new ContentType(command.contentType()),
+            new FileSize(command.fileSize()),
+            new Path(path),
+            StorageType.LOCAL);
+        FileAttachment fileAttachment = FileAttachment.create(
+            command.roomId(), command.requesterId(), metadata, FileType.fromContentType(new ContentType(command.contentType())), FileSecurity.defaultPrivate());
+
+        FileAttachment savedFileAttachment = saveFileAttachmentPort.save(fileAttachment);
+        return FileAttachmentQueryResult.of(savedFileAttachment);
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/UploadFileAttachmentService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/UploadFileAttachmentService.java
@@ -65,7 +65,7 @@ public class UploadFileAttachmentService implements UploadFileAttachmentUsecase 
         }
 
         // 파일 업로드
-        String path = "chat/" + command.roomId() + "/attachments/" + command.messageId() + "/";
+        String path = "uploads/chat/" + command.roomId() + "/attachments/" + command.messageId() + "/";
         StorageResource resource = new StorageResource(
             path,
             command.originalFileName(),
@@ -83,6 +83,7 @@ public class UploadFileAttachmentService implements UploadFileAttachmentUsecase 
             StorageType.LOCAL);
         FileAttachment fileAttachment = FileAttachment.create(
             command.roomId(), command.requesterId(), metadata, FileType.fromContentType(new ContentType(command.contentType())), FileSecurity.defaultPrivate());
+        fileAttachment.setMessageId(command.messageId());
 
         FileAttachment savedFileAttachment = saveFileAttachmentPort.save(fileAttachment);
         return FileAttachmentQueryResult.of(savedFileAttachment);

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/ChatServiceTestFixtures.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/ChatServiceTestFixtures.java
@@ -3,13 +3,22 @@ package com.lrchan.qootalk.application.chat.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
 import com.lrchan.qootalk.domain.chat.message.Message;
 import com.lrchan.qootalk.domain.chat.message.MessageType;
 import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
 import com.lrchan.qootalk.domain.chat.participant.RoomRole;
 import com.lrchan.qootalk.domain.chat.room.ChatRoom;
 import com.lrchan.qootalk.domain.chat.room.RoomType;
+import com.lrchan.qootalk.domain.chat.vo.ContentType;
+import com.lrchan.qootalk.domain.chat.vo.FileMetadata;
+import com.lrchan.qootalk.domain.chat.vo.FileName;
+import com.lrchan.qootalk.domain.chat.vo.FileSecurity;
+import com.lrchan.qootalk.domain.chat.vo.FileSize;
+import com.lrchan.qootalk.domain.chat.vo.Path;
 import com.lrchan.qootalk.domain.chat.vo.RoomName;
+import com.lrchan.qootalk.domain.chat.vo.StorageType;
 import com.lrchan.qootalk.domain.user.User;
 import com.lrchan.qootalk.domain.user.UserRole;
 import com.lrchan.qootalk.domain.user.vo.Email;
@@ -124,6 +133,56 @@ final class ChatServiceTestFixtures {
             now.minusMinutes(1),
             now.minusMinutes(1),
             null
+        );
+    }
+
+    static FileAttachment attachment(Long id, Long roomId, Long messageId, Long uploaderId, String fileName, FileType fileType) {
+        LocalDateTime now = LocalDateTime.now();
+        FileMetadata metadata = new FileMetadata(
+            new FileName(fileName),
+            new FileName("stored-" + fileName),
+            new ContentType("application/pdf"),
+            new FileSize(1024L),
+            new Path("uploads/chat/" + roomId + "/attachments/" + messageId + "/"),
+            StorageType.LOCAL
+        );
+
+        return FileAttachment.reconstruct(
+            id,
+            roomId,
+            messageId,
+            uploaderId,
+            metadata,
+            fileType,
+            FileSecurity.defaultPrivate(),
+            now.minusDays(1),
+            now.minusHours(1),
+            null
+        );
+    }
+
+    static FileAttachment deletedAttachment(Long id, Long roomId, Long messageId, Long uploaderId, String fileName, FileType fileType) {
+        LocalDateTime now = LocalDateTime.now();
+        FileMetadata metadata = new FileMetadata(
+            new FileName(fileName),
+            new FileName("stored-" + fileName),
+            new ContentType("application/pdf"),
+            new FileSize(1024L),
+            new Path("uploads/chat/" + roomId + "/attachments/" + messageId + "/"),
+            StorageType.LOCAL
+        );
+
+        return FileAttachment.reconstruct(
+            id,
+            roomId,
+            messageId,
+            uploaderId,
+            metadata,
+            fileType,
+            FileSecurity.defaultPrivate(),
+            now.minusDays(1),
+            now.minusHours(1),
+            now.minusMinutes(1)
         );
     }
 }

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/DeleteFileAttachmentServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/DeleteFileAttachmentServiceTest.java
@@ -1,0 +1,102 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.DeleteFileAttachmentCommand;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteFileAttachmentQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.DeleteFileAttachmentPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteFileAttachmentServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadChatRoomPort loadChatRoomPort;
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+    @Mock
+    private LoadFileAttachmentPort loadFileAttachmentPort;
+    @Mock
+    private DeleteFileAttachmentPort deleteFileAttachmentPort;
+
+    @InjectMocks
+    private DeleteFileAttachmentService deleteFileAttachmentService;
+
+    @Test
+    @DisplayName("업로더는 자신의 첨부파일을 삭제할 수 있다")
+    void delete_success_whenRequesterIsUploader() {
+        DeleteFileAttachmentCommand command = new DeleteFileAttachmentCommand(1L, 100L, 300L);
+        FileAttachment attachment = ChatServiceTestFixtures.attachment(300L, 100L, 200L, 1L, "architecture.pdf", FileType.DOCUMENT);
+        FileAttachment deletedAttachment = ChatServiceTestFixtures.deletedAttachment(300L, 100L, 200L, 1L, "architecture.pdf", FileType.DOCUMENT);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(10L, 1L, 100L, 200L, RoomRole.MEMBER, true)));
+        given(loadFileAttachmentPort.findById(300L)).willReturn(Optional.of(attachment));
+        given(deleteFileAttachmentPort.delete(any(FileAttachment.class))).willReturn(deletedAttachment);
+
+        DeleteFileAttachmentQueryResult result = deleteFileAttachmentService.delete(command);
+
+        assertThat(result.id()).isEqualTo(300L);
+        assertThat(result.deletedAt()).isNotNull();
+        verify(deleteFileAttachmentPort).delete(attachment);
+    }
+
+    @Test
+    @DisplayName("권한이 없는 참여자는 다른 사용자의 첨부파일을 삭제할 수 없다")
+    void delete_fail_whenRequesterHasNoPermission() {
+        DeleteFileAttachmentCommand command = new DeleteFileAttachmentCommand(1L, 100L, 300L);
+        FileAttachment attachment = ChatServiceTestFixtures.attachment(300L, 100L, 200L, 2L, "architecture.pdf", FileType.DOCUMENT);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(10L, 1L, 100L, 200L, RoomRole.MEMBER, true)));
+        given(loadFileAttachmentPort.findById(300L)).willReturn(Optional.of(attachment));
+
+        assertThatThrownBy(() -> deleteFileAttachmentService.delete(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_ROOM_PARTICIPANT_INVALID_ROLE.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 첨부파일은 다시 삭제할 수 없다")
+    void delete_fail_whenAttachmentDeleted() {
+        DeleteFileAttachmentCommand command = new DeleteFileAttachmentCommand(1L, 100L, 300L);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(10L, 1L, 100L, 200L, RoomRole.OWNER, true)));
+        given(loadFileAttachmentPort.findById(300L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.deletedAttachment(300L, 100L, 200L, 1L, "architecture.pdf", FileType.DOCUMENT)));
+
+        assertThatThrownBy(() -> deleteFileAttachmentService.delete(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_FILE_ATTACHMENT_DELETED.getMessage());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/LoadFileAttachmentsServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/LoadFileAttachmentsServiceTest.java
@@ -1,0 +1,98 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+
+import com.lrchan.qootalk.application.chat.dto.command.LoadFileAttachmentsCommand;
+import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.common.response.PagedResponse;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+
+@ExtendWith(MockitoExtension.class)
+class LoadFileAttachmentsServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadChatRoomPort loadChatRoomPort;
+    @Mock
+    private LoadFileAttachmentPort loadFileAttachmentPort;
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+
+    @InjectMocks
+    private LoadFileAttachmentsService loadFileAttachmentsService;
+
+    @Test
+    @DisplayName("첨부파일 목록 조회에 성공하면 페이징 결과를 반환한다")
+    void load_success() {
+        LoadFileAttachmentsCommand command = new LoadFileAttachmentsCommand(1L, 100L, 2L, FileType.DOCUMENT, 0, 10);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(10L, 1L, 100L, 200L, RoomRole.MEMBER, true)));
+        given(loadFileAttachmentPort.findPageByRoomIdAndUploaderIdAndFileType(100L, 2L, FileType.DOCUMENT, 0, 10))
+            .willReturn(new PageImpl<>(List.of(
+                ChatServiceTestFixtures.attachment(300L, 100L, 200L, 2L, "architecture.pdf", FileType.DOCUMENT),
+                ChatServiceTestFixtures.attachment(301L, 100L, 201L, 2L, "erd.pdf", FileType.DOCUMENT)
+            )));
+
+        PagedResponse<FileAttachmentQueryResult> result = loadFileAttachmentsService.load(command);
+
+        assertThat(result.content()).hasSize(2);
+        assertThat(result.page()).isEqualTo(0);
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.totalElements()).isEqualTo(2);
+        assertThat(result.content())
+            .extracting(FileAttachmentQueryResult::id)
+            .containsExactly(300L, 301L);
+    }
+
+    @Test
+    @DisplayName("삭제된 채팅방의 첨부파일은 조회할 수 없다")
+    void load_fail_whenRoomDeleted() {
+        LoadFileAttachmentsCommand command = new LoadFileAttachmentsCommand(1L, 100L, 2L, FileType.DOCUMENT, 0, 10);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.deletedRoom(100L, 1L)));
+
+        assertThatThrownBy(() -> loadFileAttachmentsService.load(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_ROOM_DELETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("삭제된 참여자는 첨부파일 목록을 조회할 수 없다")
+    void load_fail_whenParticipantDeleted() {
+        LoadFileAttachmentsCommand command = new LoadFileAttachmentsCommand(1L, 100L, 2L, FileType.DOCUMENT, 0, 10);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.deletedParticipant(10L, 1L, 100L, 200L, RoomRole.MEMBER)));
+
+        assertThatThrownBy(() -> loadFileAttachmentsService.load(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_ROOM_PARTICIPANT_DELETED.getMessage());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/UploadFileAttachmentServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/UploadFileAttachmentServiceTest.java
@@ -1,0 +1,130 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.UploadFileAttachmentCommand;
+import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveFileAttachmentPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.application.user.port.out.UploadFilePort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class UploadFileAttachmentServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadChatRoomPort loadChatRoomPort;
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+    @Mock
+    private UploadFilePort uploadFilePort;
+    @Mock
+    private SaveFileAttachmentPort saveFileAttachmentPort;
+
+    @InjectMocks
+    private UploadFileAttachmentService uploadFileAttachmentService;
+
+    @Test
+    @DisplayName("첨부파일 업로드에 성공하면 메시지 ID와 저장 경로가 함께 저장된다")
+    void upload_success() {
+        UploadFileAttachmentCommand command = new UploadFileAttachmentCommand(
+            1L,
+            100L,
+            200L,
+            new ByteArrayInputStream("pdf".getBytes(StandardCharsets.UTF_8)),
+            "architecture.pdf",
+            "application/pdf",
+            1024L
+        );
+        FileAttachment savedAttachment = ChatServiceTestFixtures.attachment(300L, 100L, 200L, 1L, "architecture.pdf", FileType.DOCUMENT);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(10L, 1L, 100L, 200L, RoomRole.MEMBER, true)));
+        given(uploadFilePort.upload(any(), any()))
+            .willReturn("http://localhost:4566/uploads/chat/100/attachments/200/stored-architecture.pdf");
+        given(saveFileAttachmentPort.save(any(FileAttachment.class))).willReturn(savedAttachment);
+
+        FileAttachmentQueryResult result = uploadFileAttachmentService.upload(command);
+
+        assertThat(result.id()).isEqualTo(300L);
+        assertThat(result.messageId()).isEqualTo(200L);
+        assertThat(result.storagePath().value()).isEqualTo("uploads/chat/100/attachments/200/");
+        assertThat(result.fileType()).isEqualTo(FileType.DOCUMENT);
+
+        ArgumentCaptor<FileAttachment> attachmentCaptor = ArgumentCaptor.forClass(FileAttachment.class);
+        verify(saveFileAttachmentPort).save(attachmentCaptor.capture());
+        FileAttachment captured = attachmentCaptor.getValue();
+        assertThat(captured.messageId()).isEqualTo(200L);
+        assertThat(captured.metadata().storagePath().value()).isEqualTo("uploads/chat/100/attachments/200/");
+        assertThat(captured.metadata().storedFileName().value()).isEqualTo("stored-architecture.pdf");
+    }
+
+    @Test
+    @DisplayName("삭제된 사용자는 첨부파일을 업로드할 수 없다")
+    void upload_fail_whenRequesterDeleted() {
+        UploadFileAttachmentCommand command = new UploadFileAttachmentCommand(
+            1L,
+            100L,
+            200L,
+            new ByteArrayInputStream("pdf".getBytes(StandardCharsets.UTF_8)),
+            "architecture.pdf",
+            "application/pdf",
+            1024L
+        );
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.deletedUser(1L)));
+
+        assertThatThrownBy(() -> uploadFileAttachmentService.upload(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(UserErrorCode.USER_DELETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("채팅방 참여자가 아니면 첨부파일을 업로드할 수 없다")
+    void upload_fail_whenParticipantNotFound() {
+        UploadFileAttachmentCommand command = new UploadFileAttachmentCommand(
+            1L,
+            100L,
+            200L,
+            new ByteArrayInputStream("pdf".getBytes(StandardCharsets.UTF_8)),
+            "architecture.pdf",
+            "application/pdf",
+            1024L
+        );
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(100L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(100L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 100L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> uploadFileAttachmentService.upload(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND.getMessage());
+    }
+}

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/attachment/FileAttachment.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/attachment/FileAttachment.java
@@ -9,13 +9,13 @@ import com.lrchan.qootalk.domain.common.BaseModel;
 
 public class FileAttachment extends BaseModel {
 
-    private final Long roomId;
-    private final Long messageId;
-    private final Long uploaderId;
+    private Long roomId;
+    private Long messageId;
+    private Long uploaderId;
 
-    private final FileMetadata metadata;
-    private final FileType fileType;
-    private final FileSecurity fileSecurity;
+    private FileMetadata metadata;
+    private FileType fileType;
+    private FileSecurity fileSecurity;
 
     private FileAttachment(
             Long id,
@@ -30,7 +30,7 @@ public class FileAttachment extends BaseModel {
             LocalDateTime deletedAt) {
         super(id, createdAt, updatedAt, deletedAt);
         this.roomId = Objects.requireNonNull(roomId);
-        this.messageId = Objects.requireNonNull(messageId);
+        this.messageId = messageId;
         this.uploaderId = Objects.requireNonNull(uploaderId);
         this.metadata = Objects.requireNonNull(metadata);
         this.fileType = fileType == null ? FileType.DOCUMENT : fileType;
@@ -39,7 +39,6 @@ public class FileAttachment extends BaseModel {
 
     public static FileAttachment create(
             Long roomId,
-            Long messageId,
             Long uploaderId,
             FileMetadata metadata,
             FileType fileType,
@@ -47,7 +46,7 @@ public class FileAttachment extends BaseModel {
         return new FileAttachment(
                 null,
                 roomId,
-                messageId,
+                null,
                 uploaderId,
                 metadata,
                 fileType,
@@ -80,6 +79,10 @@ public class FileAttachment extends BaseModel {
                 createdAt,
                 updatedAt,
                 deletedAt);
+    }
+
+    public void setMessageId(Long messageId) {
+        this.messageId = Objects.requireNonNull(messageId);
     }
 
     public Long roomId() {

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/attachment/FileAttachment.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/attachment/FileAttachment.java
@@ -9,6 +9,7 @@ import com.lrchan.qootalk.domain.common.BaseModel;
 
 public class FileAttachment extends BaseModel {
 
+    private final Long roomId;
     private final Long messageId;
     private final Long uploaderId;
 
@@ -18,6 +19,7 @@ public class FileAttachment extends BaseModel {
 
     private FileAttachment(
             Long id,
+            Long roomId,
             Long messageId,
             Long uploaderId,
             FileMetadata metadata,
@@ -27,6 +29,7 @@ public class FileAttachment extends BaseModel {
             LocalDateTime updatedAt,
             LocalDateTime deletedAt) {
         super(id, createdAt, updatedAt, deletedAt);
+        this.roomId = Objects.requireNonNull(roomId);
         this.messageId = Objects.requireNonNull(messageId);
         this.uploaderId = Objects.requireNonNull(uploaderId);
         this.metadata = Objects.requireNonNull(metadata);
@@ -35,6 +38,7 @@ public class FileAttachment extends BaseModel {
     }
 
     public static FileAttachment create(
+            Long roomId,
             Long messageId,
             Long uploaderId,
             FileMetadata metadata,
@@ -42,6 +46,7 @@ public class FileAttachment extends BaseModel {
             FileSecurity fileSecurity) {
         return new FileAttachment(
                 null,
+                roomId,
                 messageId,
                 uploaderId,
                 metadata,
@@ -55,6 +60,7 @@ public class FileAttachment extends BaseModel {
     // DB 복구 전용 메서드
     public static FileAttachment reconstruct(
             Long id,
+            Long roomId,
             Long messageId,
             Long uploaderId,
             FileMetadata metadata,
@@ -65,6 +71,7 @@ public class FileAttachment extends BaseModel {
             LocalDateTime deletedAt) {
         return new FileAttachment(
                 id,
+                roomId,
                 messageId,
                 uploaderId,
                 metadata,
@@ -73,6 +80,10 @@ public class FileAttachment extends BaseModel {
                 createdAt,
                 updatedAt,
                 deletedAt);
+    }
+
+    public Long roomId() {
+        return roomId;
     }
 
     public Long messageId() {

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/attachment/FileType.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/attachment/FileType.java
@@ -1,9 +1,24 @@
 package com.lrchan.qootalk.domain.chat.attachment;
 
+import com.lrchan.qootalk.domain.chat.vo.ContentType;
+
 public enum FileType {
     IMAGE,
     VIDEO,
     DOCUMENT,
     AUDIO,
-    OTHER
+    OTHER;
+
+    public static FileType fromContentType(ContentType contentType) {
+        if (contentType.value().startsWith("image/")) {
+            return IMAGE;
+        } else if (contentType.value().startsWith("video/")) {
+            return VIDEO;
+        } else if (contentType.value().startsWith("audio/")) {
+            return AUDIO;
+        } else if (contentType.value().startsWith("application/pdf") || contentType.value().startsWith("application/msword") || contentType.value().startsWith("application/vnd.openxmlformats-officedocument.wordprocessingml.document")) {
+            return DOCUMENT;
+        }
+        return OTHER;
+    }
 }

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
@@ -21,7 +21,9 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_FILE_SECURITY_INVALID_MALICIOUS_FILE_DOWNLOADABLE_OR_SHAREABLE("CHAT_014", "악성 파일은 다운로드 및 공유가 불가능합니다.", 400),
     CHAT_FILE_SECURITY_INVALID_PUBLIC_FILE_DOWNLOADABLE("CHAT_015", "공개 파일의 다운로드를 비활성화할 수 없습니다.", 400),
     CHAT_FILE_METADATA_INVALID_PATH("CHAT_016", "파일 경로가 올바르지 않습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_INPUT_STREAM("CHAT_017", "파일 입력 스트림이 올바르지 않습니다.", 400);
+    CHAT_FILE_METADATA_INVALID_INPUT_STREAM("CHAT_017", "파일 입력 스트림이 올바르지 않습니다.", 400),
+    CHAT_FILE_ATTACHMENT_NOT_FOUND("CHAT_018", "파일 첨부파일을 찾을 수 없습니다.", 404),
+    CHAT_FILE_ATTACHMENT_DELETED("CHAT_019", "파일 첨부파일이 삭제되었습니다.", 404);
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
@@ -20,7 +20,8 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_FILE_METADATA_INVALID_FILE_SIZE("CHAT_013", "파일 크기가 올바르지 않습니다.", 400),
     CHAT_FILE_SECURITY_INVALID_MALICIOUS_FILE_DOWNLOADABLE_OR_SHAREABLE("CHAT_014", "악성 파일은 다운로드 및 공유가 불가능합니다.", 400),
     CHAT_FILE_SECURITY_INVALID_PUBLIC_FILE_DOWNLOADABLE("CHAT_015", "공개 파일의 다운로드를 비활성화할 수 없습니다.", 400),
-    CHAT_FILE_METADATA_INVALID_PATH("CHAT_016", "파일 경로가 올바르지 않습니다.", 400);
+    CHAT_FILE_METADATA_INVALID_PATH("CHAT_016", "파일 경로가 올바르지 않습니다.", 400),
+    CHAT_FILE_METADATA_INVALID_INPUT_STREAM("CHAT_017", "파일 입력 스트림이 올바르지 않습니다.", 400);
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/attachment/FileAttachmentTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/attachment/FileAttachmentTest.java
@@ -41,6 +41,7 @@ class FileAttachmentTest {
         @DisplayName("유효한 데이터로 FileAttachment를 생성할 수 있다")
         void should_CreateFileAttachment_When_ValidData() {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
@@ -49,6 +50,7 @@ class FileAttachmentTest {
 
             // when
             FileAttachment fileAttachment = FileAttachment.create(
+                roomId,
                 messageId,
                 uploaderId,
                 metadata,
@@ -57,6 +59,7 @@ class FileAttachmentTest {
             );
 
             // then
+            assertThat(fileAttachment.roomId()).isEqualTo(roomId);
             assertThat(fileAttachment.messageId()).isEqualTo(messageId);
             assertThat(fileAttachment.uploaderId()).isEqualTo(uploaderId);
             assertThat(fileAttachment.metadata()).isEqualTo(metadata);
@@ -70,19 +73,20 @@ class FileAttachmentTest {
         @DisplayName("다양한 파일 타입으로 생성할 수 있다")
         void should_CreateFileAttachment_When_VariousFileTypes() {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
             FileSecurity fileSecurity = createFileSecurity();
 
             // when & then
-            assertThat(FileAttachment.create(messageId, uploaderId, metadata, FileType.IMAGE, fileSecurity)
+            assertThat(FileAttachment.create(roomId, messageId, uploaderId, metadata, FileType.IMAGE, fileSecurity)
                 .fileType()).isEqualTo(FileType.IMAGE);
-            assertThat(FileAttachment.create(messageId, uploaderId, metadata, FileType.VIDEO, fileSecurity)
+            assertThat(FileAttachment.create(roomId, messageId, uploaderId, metadata, FileType.VIDEO, fileSecurity)
                 .fileType()).isEqualTo(FileType.VIDEO);
-            assertThat(FileAttachment.create(messageId, uploaderId, metadata, FileType.AUDIO, fileSecurity)
+            assertThat(FileAttachment.create(roomId, messageId, uploaderId, metadata, FileType.AUDIO, fileSecurity)
                 .fileType()).isEqualTo(FileType.AUDIO);
-            assertThat(FileAttachment.create(messageId, uploaderId, metadata, FileType.OTHER, fileSecurity)
+            assertThat(FileAttachment.create(roomId, messageId, uploaderId, metadata, FileType.OTHER, fileSecurity)
                 .fileType()).isEqualTo(FileType.OTHER);
         }
 
@@ -90,6 +94,7 @@ class FileAttachmentTest {
         @DisplayName("다양한 FileSecurity 설정으로 생성할 수 있다")
         void should_CreateFileAttachment_When_VariousFileSecurity() {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
@@ -97,12 +102,12 @@ class FileAttachmentTest {
 
             // when & then
             FileAttachment privateAttachment = FileAttachment.create(
-                messageId, uploaderId, metadata, fileType, FileSecurity.defaultPrivate()
+                roomId, messageId, uploaderId, metadata, fileType, FileSecurity.defaultPrivate()
             );
             assertThat(privateAttachment.fileSecurity().visibility()).isEqualTo(com.lrchan.qootalk.domain.chat.vo.Visibility.PRIVATE);
 
             FileAttachment publicAttachment = FileAttachment.create(
-                messageId, uploaderId, metadata, fileType, FileSecurity.publicReadable()
+                roomId, messageId, uploaderId, metadata, fileType, FileSecurity.publicReadable()
             );
             assertThat(publicAttachment.fileSecurity().visibility()).isEqualTo(com.lrchan.qootalk.domain.chat.vo.Visibility.PUBLIC);
         }
@@ -111,6 +116,7 @@ class FileAttachmentTest {
         @DisplayName("다양한 FileMetadata로 생성할 수 있다")
         void should_CreateFileAttachment_When_VariousFileMetadata() {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             Long uploaderId = 100L;
             FileType fileType = FileType.IMAGE;
@@ -127,6 +133,7 @@ class FileAttachmentTest {
             );
 
             FileAttachment fileAttachment = FileAttachment.create(
+                roomId,
                 messageId,
                 uploaderId,
                 imageMetadata,
@@ -148,6 +155,7 @@ class FileAttachmentTest {
         @DisplayName("messageId가 null이면 예외가 발생한다")
         void should_ThrowException_When_MessageIdIsNull() {
             // given
+            Long roomId = 10L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
             FileType fileType = FileType.DOCUMENT;
@@ -155,6 +163,7 @@ class FileAttachmentTest {
 
             // when & then
             assertThatThrownBy(() -> FileAttachment.create(
+                roomId,
                 null,
                 uploaderId,
                 metadata,
@@ -168,6 +177,7 @@ class FileAttachmentTest {
         @DisplayName("uploaderId가 null이면 예외가 발생한다")
         void should_ThrowException_When_UploaderIdIsNull() {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             FileMetadata metadata = createFileMetadata();
             FileType fileType = FileType.DOCUMENT;
@@ -175,6 +185,7 @@ class FileAttachmentTest {
 
             // when & then
             assertThatThrownBy(() -> FileAttachment.create(
+                roomId,
                 messageId,
                 null,
                 metadata,
@@ -188,6 +199,7 @@ class FileAttachmentTest {
         @DisplayName("metadata가 null이면 예외가 발생한다")
         void should_ThrowException_When_MetadataIsNull() {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             Long uploaderId = 100L;
             FileType fileType = FileType.DOCUMENT;
@@ -195,6 +207,7 @@ class FileAttachmentTest {
 
             // when & then
             assertThatThrownBy(() -> FileAttachment.create(
+                roomId,
                 messageId,
                 uploaderId,
                 null,
@@ -213,6 +226,7 @@ class FileAttachmentTest {
         @DisplayName("생성 시 id는 null이다")
         void should_HaveNullId_When_Created() {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
@@ -221,6 +235,7 @@ class FileAttachmentTest {
 
             // when
             FileAttachment fileAttachment = FileAttachment.create(
+                roomId,
                 messageId,
                 uploaderId,
                 metadata,
@@ -236,6 +251,7 @@ class FileAttachmentTest {
         @DisplayName("생성 시 삭제되지 않은 상태이다")
         void should_NotBeDeleted_When_Created() {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
@@ -244,6 +260,7 @@ class FileAttachmentTest {
 
             // when
             FileAttachment fileAttachment = FileAttachment.create(
+                roomId,
                 messageId,
                 uploaderId,
                 metadata,
@@ -259,6 +276,7 @@ class FileAttachmentTest {
         @DisplayName("softDelete를 호출하면 삭제 상태가 된다")
         void should_BeDeleted_When_SoftDeleteCalled() {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
@@ -266,6 +284,7 @@ class FileAttachmentTest {
             FileSecurity fileSecurity = createFileSecurity();
 
             FileAttachment fileAttachment = FileAttachment.create(
+                roomId,
                 messageId,
                 uploaderId,
                 metadata,
@@ -284,6 +303,7 @@ class FileAttachmentTest {
         @DisplayName("update를 호출하면 updatedAt이 갱신된다")
         void should_UpdateTimestamp_When_UpdateCalled() throws InterruptedException {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
@@ -291,6 +311,7 @@ class FileAttachmentTest {
             FileSecurity fileSecurity = createFileSecurity();
 
             FileAttachment fileAttachment = FileAttachment.create(
+                roomId,
                 messageId,
                 uploaderId,
                 metadata,
@@ -315,6 +336,7 @@ class FileAttachmentTest {
         @DisplayName("모든 접근자 메서드가 올바른 값을 반환한다")
         void should_ReturnCorrectValues_When_AccessorMethodsCalled() {
             // given
+            Long roomId = 10L;
             Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
@@ -323,6 +345,7 @@ class FileAttachmentTest {
 
             // when
             FileAttachment fileAttachment = FileAttachment.create(
+                roomId,
                 messageId,
                 uploaderId,
                 metadata,
@@ -331,6 +354,7 @@ class FileAttachmentTest {
             );
 
             // then
+            assertThat(fileAttachment.roomId()).isEqualTo(roomId);
             assertThat(fileAttachment.messageId()).isEqualTo(messageId);
             assertThat(fileAttachment.uploaderId()).isEqualTo(uploaderId);
             assertThat(fileAttachment.metadata()).isEqualTo(metadata);

--- a/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/attachment/FileAttachmentTest.java
+++ b/qootalk-server/module-domain/src/test/java/com/lrchan/qootalk/domain/chat/attachment/FileAttachmentTest.java
@@ -42,28 +42,24 @@ class FileAttachmentTest {
         void should_CreateFileAttachment_When_ValidData() {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
-            FileType fileType = FileType.DOCUMENT;
             FileSecurity fileSecurity = createFileSecurity();
 
             // when
             FileAttachment fileAttachment = FileAttachment.create(
                 roomId,
-                messageId,
                 uploaderId,
                 metadata,
-                fileType,
+                FileType.fromContentType(metadata.contentType()),
                 fileSecurity
             );
 
             // then
             assertThat(fileAttachment.roomId()).isEqualTo(roomId);
-            assertThat(fileAttachment.messageId()).isEqualTo(messageId);
             assertThat(fileAttachment.uploaderId()).isEqualTo(uploaderId);
             assertThat(fileAttachment.metadata()).isEqualTo(metadata);
-            assertThat(fileAttachment.fileType()).isEqualTo(fileType);
+            assertThat(fileAttachment.fileType()).isEqualTo(FileType.fromContentType(metadata.contentType()));
             assertThat(fileAttachment.fileSecurity()).isEqualTo(fileSecurity);
             assertThat(fileAttachment.id()).isNull();
             assertThat(fileAttachment.isDeleted()).isFalse();
@@ -74,19 +70,18 @@ class FileAttachmentTest {
         void should_CreateFileAttachment_When_VariousFileTypes() {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
             FileSecurity fileSecurity = createFileSecurity();
 
             // when & then
-            assertThat(FileAttachment.create(roomId, messageId, uploaderId, metadata, FileType.IMAGE, fileSecurity)
+            assertThat(FileAttachment.create(roomId, uploaderId, metadata, FileType.IMAGE, fileSecurity)
                 .fileType()).isEqualTo(FileType.IMAGE);
-            assertThat(FileAttachment.create(roomId, messageId, uploaderId, metadata, FileType.VIDEO, fileSecurity)
+            assertThat(FileAttachment.create(roomId, uploaderId, metadata, FileType.VIDEO, fileSecurity)
                 .fileType()).isEqualTo(FileType.VIDEO);
-            assertThat(FileAttachment.create(roomId, messageId, uploaderId, metadata, FileType.AUDIO, fileSecurity)
+            assertThat(FileAttachment.create(roomId, uploaderId, metadata, FileType.AUDIO, fileSecurity)
                 .fileType()).isEqualTo(FileType.AUDIO);
-            assertThat(FileAttachment.create(roomId, messageId, uploaderId, metadata, FileType.OTHER, fileSecurity)
+            assertThat(FileAttachment.create(roomId, uploaderId, metadata, FileType.OTHER, fileSecurity)
                 .fileType()).isEqualTo(FileType.OTHER);
         }
 
@@ -95,19 +90,18 @@ class FileAttachmentTest {
         void should_CreateFileAttachment_When_VariousFileSecurity() {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
             FileType fileType = FileType.DOCUMENT;
 
             // when & then
             FileAttachment privateAttachment = FileAttachment.create(
-                roomId, messageId, uploaderId, metadata, fileType, FileSecurity.defaultPrivate()
+                roomId, uploaderId, metadata, fileType, FileSecurity.defaultPrivate()
             );
             assertThat(privateAttachment.fileSecurity().visibility()).isEqualTo(com.lrchan.qootalk.domain.chat.vo.Visibility.PRIVATE);
 
             FileAttachment publicAttachment = FileAttachment.create(
-                roomId, messageId, uploaderId, metadata, fileType, FileSecurity.publicReadable()
+                roomId, uploaderId, metadata, fileType, FileSecurity.publicReadable()
             );
             assertThat(publicAttachment.fileSecurity().visibility()).isEqualTo(com.lrchan.qootalk.domain.chat.vo.Visibility.PUBLIC);
         }
@@ -117,7 +111,6 @@ class FileAttachmentTest {
         void should_CreateFileAttachment_When_VariousFileMetadata() {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             Long uploaderId = 100L;
             FileType fileType = FileType.IMAGE;
             FileSecurity fileSecurity = createFileSecurity();
@@ -134,7 +127,6 @@ class FileAttachmentTest {
 
             FileAttachment fileAttachment = FileAttachment.create(
                 roomId,
-                messageId,
                 uploaderId,
                 imageMetadata,
                 fileType,
@@ -152,33 +144,10 @@ class FileAttachmentTest {
     class ValidationFailureTest {
 
         @Test
-        @DisplayName("messageId가 null이면 예외가 발생한다")
-        void should_ThrowException_When_MessageIdIsNull() {
-            // given
-            Long roomId = 10L;
-            Long uploaderId = 100L;
-            FileMetadata metadata = createFileMetadata();
-            FileType fileType = FileType.DOCUMENT;
-            FileSecurity fileSecurity = createFileSecurity();
-
-            // when & then
-            assertThatThrownBy(() -> FileAttachment.create(
-                roomId,
-                null,
-                uploaderId,
-                metadata,
-                fileType,
-                fileSecurity
-            ))
-            .isInstanceOf(NullPointerException.class);
-        }
-
-        @Test
         @DisplayName("uploaderId가 null이면 예외가 발생한다")
         void should_ThrowException_When_UploaderIdIsNull() {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             FileMetadata metadata = createFileMetadata();
             FileType fileType = FileType.DOCUMENT;
             FileSecurity fileSecurity = createFileSecurity();
@@ -186,7 +155,6 @@ class FileAttachmentTest {
             // when & then
             assertThatThrownBy(() -> FileAttachment.create(
                 roomId,
-                messageId,
                 null,
                 metadata,
                 fileType,
@@ -200,7 +168,6 @@ class FileAttachmentTest {
         void should_ThrowException_When_MetadataIsNull() {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             Long uploaderId = 100L;
             FileType fileType = FileType.DOCUMENT;
             FileSecurity fileSecurity = createFileSecurity();
@@ -208,7 +175,6 @@ class FileAttachmentTest {
             // when & then
             assertThatThrownBy(() -> FileAttachment.create(
                 roomId,
-                messageId,
                 uploaderId,
                 null,
                 fileType,
@@ -227,7 +193,6 @@ class FileAttachmentTest {
         void should_HaveNullId_When_Created() {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
             FileType fileType = FileType.DOCUMENT;
@@ -236,7 +201,6 @@ class FileAttachmentTest {
             // when
             FileAttachment fileAttachment = FileAttachment.create(
                 roomId,
-                messageId,
                 uploaderId,
                 metadata,
                 fileType,
@@ -252,7 +216,6 @@ class FileAttachmentTest {
         void should_NotBeDeleted_When_Created() {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
             FileType fileType = FileType.DOCUMENT;
@@ -261,7 +224,6 @@ class FileAttachmentTest {
             // when
             FileAttachment fileAttachment = FileAttachment.create(
                 roomId,
-                messageId,
                 uploaderId,
                 metadata,
                 fileType,
@@ -277,7 +239,6 @@ class FileAttachmentTest {
         void should_BeDeleted_When_SoftDeleteCalled() {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
             FileType fileType = FileType.DOCUMENT;
@@ -285,7 +246,6 @@ class FileAttachmentTest {
 
             FileAttachment fileAttachment = FileAttachment.create(
                 roomId,
-                messageId,
                 uploaderId,
                 metadata,
                 fileType,
@@ -304,7 +264,6 @@ class FileAttachmentTest {
         void should_UpdateTimestamp_When_UpdateCalled() throws InterruptedException {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
             FileType fileType = FileType.DOCUMENT;
@@ -312,7 +271,6 @@ class FileAttachmentTest {
 
             FileAttachment fileAttachment = FileAttachment.create(
                 roomId,
-                messageId,
                 uploaderId,
                 metadata,
                 fileType,
@@ -337,7 +295,6 @@ class FileAttachmentTest {
         void should_ReturnCorrectValues_When_AccessorMethodsCalled() {
             // given
             Long roomId = 10L;
-            Long messageId = 1L;
             Long uploaderId = 100L;
             FileMetadata metadata = createFileMetadata();
             FileType fileType = FileType.DOCUMENT;
@@ -346,7 +303,6 @@ class FileAttachmentTest {
             // when
             FileAttachment fileAttachment = FileAttachment.create(
                 roomId,
-                messageId,
                 uploaderId,
                 metadata,
                 fileType,
@@ -355,7 +311,6 @@ class FileAttachmentTest {
 
             // then
             assertThat(fileAttachment.roomId()).isEqualTo(roomId);
-            assertThat(fileAttachment.messageId()).isEqualTo(messageId);
             assertThat(fileAttachment.uploaderId()).isEqualTo(uploaderId);
             assertThat(fileAttachment.metadata()).isEqualTo(metadata);
             assertThat(fileAttachment.fileType()).isEqualTo(fileType);

--- a/qootalk-server/module-infrastructure/build.gradle
+++ b/qootalk-server/module-infrastructure/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java-test-fixtures'
 }
 
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
 dependencies {
 	implementation project(':module-domain')
 	implementation project(':module-application')
@@ -12,6 +14,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.postgresql:postgresql'
+
+	// Querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -50,6 +58,18 @@ dependencies {
 
 	// AWS S3
 	implementation 'software.amazon.awssdk:s3:2.41.13'
+}
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(querydslDir)
+}
+
+clean {
+    delete querydslDir
 }
 
 tasks.named('test') {

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/QuerydslConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/QuerydslConfig.java
@@ -1,0 +1,17 @@
+package com.lrchan.qootalk.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/audit/AuditLogRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/audit/AuditLogRepositoryAdapter.java
@@ -1,5 +1,7 @@
 package com.lrchan.qootalk.infrastructure.persistence.audit;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Component;
 
 import com.lrchan.qootalk.domain.audit.AuditLog;
@@ -16,6 +18,6 @@ public class AuditLogRepositoryAdapter implements AuditLogRepository {
     @Override
     public void save(AuditLog auditLog) {
         AuditLogEntity auditLogEntity = AuditLogEntityMapper.toEntity(auditLog);
-        auditLogJpaRepository.save(auditLogEntity);
+        auditLogJpaRepository.save(Objects.requireNonNull(auditLogEntity));
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentEntity.java
@@ -25,6 +25,9 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class FileAttachmentEntity extends BaseEntity {
+
+    @Column(name = "room_id", nullable = false)
+    private Long roomId;
     
     @Column(name = "message_id", nullable = false)
     private Long messageId;

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentJpaRepository.java
@@ -3,7 +3,8 @@ package com.lrchan.qootalk.infrastructure.persistence.chat.attachment;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import com.lrchan.qootalk.infrastructure.query.chat.attachment.FileAttachmentQueryRepository;
 
-public interface FileAttachmentJpaRepository extends JpaRepository<FileAttachmentEntity, Long> {
+public interface FileAttachmentJpaRepository extends JpaRepository<FileAttachmentEntity, Long>, FileAttachmentQueryRepository {
     Optional<FileAttachmentEntity> findByMessageId(Long messageId);
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentJpaRepositoryImpl.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentJpaRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.lrchan.qootalk.infrastructure.query.chat.attachment;
+package com.lrchan.qootalk.infrastructure.persistence.chat.attachment;
 
 import java.util.List;
 
@@ -6,39 +6,33 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
-import org.springframework.stereotype.Component;
 
-import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
 import com.lrchan.qootalk.domain.chat.attachment.FileType;
-import com.lrchan.qootalk.infrastructure.persistence.chat.attachment.FileAttachmentEntity;
-import com.lrchan.qootalk.infrastructure.persistence.chat.attachment.FileAttachmentMapper;
+import com.lrchan.qootalk.infrastructure.query.chat.attachment.FileAttachmentQueryRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
-import com.lrchan.qootalk.infrastructure.persistence.chat.attachment.QFileAttachmentEntity;
-
-@Component
 @RequiredArgsConstructor
-public class FileAttachmentQueryRepositoryimpl implements FileAttachmentQueryRepository {
-    
+public class FileAttachmentJpaRepositoryImpl implements FileAttachmentQueryRepository {
+
     private final JPAQueryFactory queryFactory;
     private final QFileAttachmentEntity qFileAttachment = QFileAttachmentEntity.fileAttachmentEntity;
-    
+
     @Override
     public Page<FileAttachmentEntity> findPageByRoomIdAndUploaderIdAndFileType(
             Long roomId, Long uploaderId, FileType fileType, int page, int size) {
-        
+
         Pageable pageable = PageRequest.of(page, size);
 
         List<FileAttachmentEntity> entities = queryFactory
             .selectFrom(qFileAttachment)
             .where(
-                roomIdEq(roomId), 
-                uploaderIdEq(uploaderId), 
-                fileTypeEq(fileType), 
+                roomIdEq(roomId),
+                uploaderIdEq(uploaderId),
+                fileTypeEq(fileType),
                 qFileAttachment.deletedAt.isNull()
             )
             .orderBy(qFileAttachment.createdAt.desc())
@@ -50,15 +44,15 @@ public class FileAttachmentQueryRepositoryimpl implements FileAttachmentQueryRep
             .select(qFileAttachment.count())
             .from(qFileAttachment)
             .where(
-                roomIdEq(roomId), 
-                uploaderIdEq(uploaderId), 
-                fileTypeEq(fileType), 
+                roomIdEq(roomId),
+                uploaderIdEq(uploaderId),
+                fileTypeEq(fileType),
                 qFileAttachment.deletedAt.isNull()
             );
 
         return PageableExecutionUtils.getPage(
-            entities, 
-            pageable, 
+            entities,
+            pageable,
             countQuery::fetchOne
         );
     }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentMapper.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentMapper.java
@@ -36,6 +36,7 @@ public final class FileAttachmentMapper {
 
         return FileAttachmentEntity.builder()
                 .id(fileAttachment.id())
+                .roomId(fileAttachment.roomId())
                 .messageId(fileAttachment.messageId())
                 .uploaderId(fileAttachment.uploaderId())
                 .metadata(metadataEmbeddable)
@@ -70,6 +71,7 @@ public final class FileAttachmentMapper {
 
         return FileAttachment.reconstruct(
                 entity.getId(),
+                entity.getRoomId(),
                 entity.getMessageId(),
                 entity.getUploaderId(),
                 metadata,

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentRepositoryAdapter.java
@@ -3,14 +3,20 @@ package com.lrchan.qootalk.infrastructure.persistence.chat.attachment;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
 import com.lrchan.qootalk.application.chat.port.out.SaveFileAttachmentPort;
+import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
 import com.lrchan.qootalk.domain.chat.attachment.FileAttachmentRepository;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
 
 @Component
-public class FileAttachmentRepositoryAdapter implements FileAttachmentRepository, SaveFileAttachmentPort {
+public class FileAttachmentRepositoryAdapter implements FileAttachmentRepository, SaveFileAttachmentPort, LoadFileAttachmentPort {
     private final FileAttachmentJpaRepository fileAttachmentJpaRepository;
 
     public FileAttachmentRepositoryAdapter(FileAttachmentJpaRepository fileAttachmentJpaRepository) {
@@ -32,5 +38,12 @@ public class FileAttachmentRepositoryAdapter implements FileAttachmentRepository
         FileAttachmentEntity fileAttachmentEntity = FileAttachmentMapper.toEntity(fileAttachment);
         FileAttachmentEntity savedEntity = fileAttachmentJpaRepository.save(Objects.requireNonNull(fileAttachmentEntity));
         return FileAttachmentMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public PagedResponse<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(Long roomId, Long uploaderId, FileType fileType, int page, int size) {
+
+        Page<FileAttachment> fileAttachments = fileAttachmentJpaRepository.findPageByRoomIdAndUploaderIdAndFileType(roomId, uploaderId, fileType, page, size);
+        return PagedResponse.of(fileAttachments.getContent(), fileAttachments.getNumber(), fileAttachments.getSize(), fileAttachments.getTotalElements(), fileAttachments.getTotalPages());
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentRepositoryAdapter.java
@@ -4,11 +4,12 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
+import com.lrchan.qootalk.application.chat.port.out.SaveFileAttachmentPort;
 import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
 import com.lrchan.qootalk.domain.chat.attachment.FileAttachmentRepository;
 
 @Component
-public class FileAttachmentRepositoryAdapter implements FileAttachmentRepository {
+public class FileAttachmentRepositoryAdapter implements FileAttachmentRepository, SaveFileAttachmentPort {
     private final FileAttachmentJpaRepository fileAttachmentJpaRepository;
 
     public FileAttachmentRepositoryAdapter(FileAttachmentJpaRepository fileAttachmentJpaRepository) {

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentRepositoryAdapter.java
@@ -1,5 +1,6 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.attachment;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -18,7 +19,7 @@ public class FileAttachmentRepositoryAdapter implements FileAttachmentRepository
 
     @Override
     public Optional<FileAttachment> findById(Long id) {
-        return fileAttachmentJpaRepository.findById(id).map(FileAttachmentMapper::toDomain);
+        return fileAttachmentJpaRepository.findById(Objects.requireNonNull(id)).map(FileAttachmentMapper::toDomain);
     }
 
     @Override
@@ -29,7 +30,7 @@ public class FileAttachmentRepositoryAdapter implements FileAttachmentRepository
     @Override
     public FileAttachment save(FileAttachment fileAttachment) {
         FileAttachmentEntity fileAttachmentEntity = FileAttachmentMapper.toEntity(fileAttachment);
-        FileAttachmentEntity savedEntity = fileAttachmentJpaRepository.save(fileAttachmentEntity);
+        FileAttachmentEntity savedEntity = fileAttachmentJpaRepository.save(Objects.requireNonNull(fileAttachmentEntity));
         return FileAttachmentMapper.toDomain(savedEntity);
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentRepositoryAdapter.java
@@ -4,19 +4,17 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import com.lrchan.qootalk.application.chat.port.out.DeleteFileAttachmentPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
 import com.lrchan.qootalk.application.chat.port.out.SaveFileAttachmentPort;
-import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
 import com.lrchan.qootalk.domain.chat.attachment.FileAttachmentRepository;
 import com.lrchan.qootalk.domain.chat.attachment.FileType;
 
 @Component
-public class FileAttachmentRepositoryAdapter implements FileAttachmentRepository, SaveFileAttachmentPort, LoadFileAttachmentPort {
+public class FileAttachmentRepositoryAdapter implements FileAttachmentRepository, SaveFileAttachmentPort, LoadFileAttachmentPort, DeleteFileAttachmentPort {
     private final FileAttachmentJpaRepository fileAttachmentJpaRepository;
 
     public FileAttachmentRepositoryAdapter(FileAttachmentJpaRepository fileAttachmentJpaRepository) {
@@ -41,9 +39,16 @@ public class FileAttachmentRepositoryAdapter implements FileAttachmentRepository
     }
 
     @Override
-    public PagedResponse<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(Long roomId, Long uploaderId, FileType fileType, int page, int size) {
+    public Page<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(Long roomId, Long uploaderId, FileType fileType, int page, int size) {
 
-        Page<FileAttachment> fileAttachments = fileAttachmentJpaRepository.findPageByRoomIdAndUploaderIdAndFileType(roomId, uploaderId, fileType, page, size);
-        return PagedResponse.of(fileAttachments.getContent(), fileAttachments.getNumber(), fileAttachments.getSize(), fileAttachments.getTotalElements(), fileAttachments.getTotalPages());
+        Page<FileAttachmentEntity> fileAttachmentEntities = fileAttachmentJpaRepository.findPageByRoomIdAndUploaderIdAndFileType(roomId, uploaderId, fileType, page, size);
+        return fileAttachmentEntities.map(FileAttachmentMapper::toDomain);
+    }
+
+    @Override
+    public FileAttachment delete(FileAttachment fileAttachment) {
+        FileAttachmentEntity fileAttachmentEntity = FileAttachmentMapper.toEntity(fileAttachment);
+        FileAttachmentEntity deletedEntity = fileAttachmentJpaRepository.save(fileAttachmentEntity);
+        return FileAttachmentMapper.toDomain(deletedEntity);
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageRepositoryAdapter.java
@@ -1,5 +1,6 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.message;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -19,13 +20,13 @@ public class MessageRepositoryAdapter implements MessageRepository, SaveMessageP
     
     @Override
     public Optional<Message> findById(Long id) {
-        return messageJpaRepository.findById(id).map(MessageEntityMapper::toDomain);
+        return messageJpaRepository.findById(Objects.requireNonNull(id)).map(MessageEntityMapper::toDomain);
     }
 
     @Override
     public Message save(Message message) {
         MessageEntity messageEntity = MessageEntityMapper.toEntity(message);
-        MessageEntity savedEntity = messageJpaRepository.save(messageEntity);
+        MessageEntity savedEntity = messageJpaRepository.save(Objects.requireNonNull(messageEntity));
         return MessageEntityMapper.toDomain(savedEntity);
     }
 

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.participant;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -24,13 +25,13 @@ public class RoomParticipantRepositoryAdapter implements RoomParticipantReposito
 
     @Override
     public Optional<RoomParticipant> findById(Long id) {
-        return roomParticipantJpaRepository.findById(id).map(RoomParticipantEntityMapper::toDomain);
+        return roomParticipantJpaRepository.findById(Objects.requireNonNull(id)).map(RoomParticipantEntityMapper::toDomain);
     }
 
     @Override
     public RoomParticipant save(RoomParticipant roomParticipant) {
         RoomParticipantEntity roomParticipantEntity = RoomParticipantEntityMapper.toEntity(roomParticipant);
-        RoomParticipantEntity savedEntity = roomParticipantJpaRepository.save(roomParticipantEntity);
+        RoomParticipantEntity savedEntity = roomParticipantJpaRepository.save(Objects.requireNonNull(roomParticipantEntity));
         return RoomParticipantEntityMapper.toDomain(savedEntity);
     }
 

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomEntity.java
@@ -1,8 +1,5 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.room;
 
-import java.time.LocalDateTime;
-import java.util.Objects;
-
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/room/ChatRoomRepositoryAdapter.java
@@ -1,10 +1,8 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.room;
 
-import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
@@ -23,7 +21,7 @@ public class ChatRoomRepositoryAdapter implements ChatRoomRepository, SaveChatRo
 
     @Override
     public Optional<ChatRoom> findById(Long id) {
-        return chatRoomJpaRepository.findById(id).map(ChatRoomEntityMapper::toDomain);
+        return chatRoomJpaRepository.findById(Objects.requireNonNull(id)).map(ChatRoomEntityMapper::toDomain);
     }
 
     @Override
@@ -39,7 +37,7 @@ public class ChatRoomRepositoryAdapter implements ChatRoomRepository, SaveChatRo
     @Override
     public ChatRoom save(ChatRoom chatRoom) {
         ChatRoomEntity chatRoomEntity = ChatRoomEntityMapper.toEntity(chatRoom);
-        ChatRoomEntity savedEntity = chatRoomJpaRepository.save(chatRoomEntity);
+        ChatRoomEntity savedEntity = chatRoomJpaRepository.save(Objects.requireNonNull(chatRoomEntity));
         return ChatRoomEntityMapper.toDomain(savedEntity);
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/query/chat/attachment/FileAttachmentQueryRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/query/chat/attachment/FileAttachmentQueryRepository.java
@@ -1,11 +1,11 @@
 package com.lrchan.qootalk.infrastructure.query.chat.attachment;
 
-import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+import com.lrchan.qootalk.infrastructure.persistence.chat.attachment.FileAttachmentEntity;
 
 import org.springframework.data.domain.Page;
 
 import com.lrchan.qootalk.domain.chat.attachment.FileType;
 
 public interface FileAttachmentQueryRepository {
-    Page<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(Long roomId, Long uploaderId, FileType fileType, int page, int size);
+    Page<FileAttachmentEntity> findPageByRoomIdAndUploaderIdAndFileType(Long roomId, Long uploaderId, FileType fileType, int page, int size);
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/query/chat/attachment/FileAttachmentQueryRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/query/chat/attachment/FileAttachmentQueryRepository.java
@@ -1,0 +1,11 @@
+package com.lrchan.qootalk.infrastructure.query.chat.attachment;
+
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+
+import org.springframework.data.domain.Page;
+
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
+
+public interface FileAttachmentQueryRepository {
+    Page<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(Long roomId, Long uploaderId, FileType fileType, int page, int size);
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/query/chat/attachment/FileAttachmentQueryRepositoryimpl.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/query/chat/attachment/FileAttachmentQueryRepositoryimpl.java
@@ -1,0 +1,77 @@
+package com.lrchan.qootalk.infrastructure.query.chat.attachment;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Component;
+
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
+import com.lrchan.qootalk.infrastructure.persistence.chat.attachment.FileAttachmentEntity;
+import com.lrchan.qootalk.infrastructure.persistence.chat.attachment.FileAttachmentMapper;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+import com.lrchan.qootalk.infrastructure.persistence.chat.attachment.QFileAttachmentEntity;
+
+@Component
+@RequiredArgsConstructor
+public class FileAttachmentQueryRepositoryimpl implements FileAttachmentQueryRepository {
+    
+    private final JPAQueryFactory queryFactory;
+    private final QFileAttachmentEntity qFileAttachment = QFileAttachmentEntity.fileAttachmentEntity;
+    
+    @Override
+    public Page<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(
+            Long roomId, Long uploaderId, FileType fileType, int page, int size) {
+        
+        Pageable pageable = PageRequest.of(page, size);
+
+        List<FileAttachmentEntity> entities = queryFactory
+            .selectFrom(qFileAttachment)
+            .where(
+                roomIdEq(roomId), 
+                uploaderIdEq(uploaderId), 
+                fileTypeEq(fileType), 
+                qFileAttachment.deletedAt.isNull()
+            )
+            .orderBy(qFileAttachment.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(qFileAttachment.count())
+            .from(qFileAttachment)
+            .where(
+                roomIdEq(roomId), 
+                uploaderIdEq(uploaderId), 
+                fileTypeEq(fileType), 
+                qFileAttachment.deletedAt.isNull()
+            );
+
+        return PageableExecutionUtils.getPage(
+            entities.stream().map(FileAttachmentMapper::toDomain).toList(), 
+            pageable, 
+            countQuery::fetchOne
+        );
+    }
+
+    private BooleanExpression roomIdEq(Long roomId) {
+        return roomId != null ? qFileAttachment.roomId.eq(roomId) : null;
+    }
+
+    private BooleanExpression uploaderIdEq(Long uploaderId) {
+        return uploaderId != null ? qFileAttachment.uploaderId.eq(uploaderId) : null;
+    }
+
+    private BooleanExpression fileTypeEq(FileType fileType) {
+        return fileType != null ? qFileAttachment.fileType.eq(fileType) : null;
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/query/chat/attachment/FileAttachmentQueryRepositoryimpl.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/query/chat/attachment/FileAttachmentQueryRepositoryimpl.java
@@ -28,7 +28,7 @@ public class FileAttachmentQueryRepositoryimpl implements FileAttachmentQueryRep
     private final QFileAttachmentEntity qFileAttachment = QFileAttachmentEntity.fileAttachmentEntity;
     
     @Override
-    public Page<FileAttachment> findPageByRoomIdAndUploaderIdAndFileType(
+    public Page<FileAttachmentEntity> findPageByRoomIdAndUploaderIdAndFileType(
             Long roomId, Long uploaderId, FileType fileType, int page, int size) {
         
         Pageable pageable = PageRequest.of(page, size);
@@ -57,7 +57,7 @@ public class FileAttachmentQueryRepositoryimpl implements FileAttachmentQueryRep
             );
 
         return PageableExecutionUtils.getPage(
-            entities.stream().map(FileAttachmentMapper::toDomain).toList(), 
+            entities, 
             pageable, 
             countQuery::fetchOne
         );

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/filter/JwtAuthenticationFilter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/filter/JwtAuthenticationFilter.java
@@ -6,8 +6,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.lrchan.qootalk.common.error.GlobalErrorCode;
-import com.lrchan.qootalk.common.exception.InfrastructureException;
 import com.lrchan.qootalk.infrastructure.security.provider.JwtAuthenticationValidator;
 
 import jakarta.servlet.FilterChain;

--- a/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_6__file_attachments.sql
+++ b/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_6__file_attachments.sql
@@ -1,6 +1,7 @@
 -- file_attachments (includes @Embedded metadata + security columns)
 create table file_attachments (
   id bigserial primary key,
+  room_id bigint not null,
   message_id bigint not null,
   uploader_id bigint not null,
 
@@ -25,3 +26,4 @@ create table file_attachments (
 );
 
 create index idx_file_attachments_message_id on file_attachments(message_id);
+create index idx_file_attachments_room_id on file_attachments(room_id);

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentJpaRepositoryTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentJpaRepositoryTest.java
@@ -28,6 +28,7 @@ public class FileAttachmentJpaRepositoryTest extends IntegrationTestSupport {
     void should_saveAndFind_when_validAttachment() {
         // given
         FileAttachmentEntity fileAttachmentEntity = FileAttachmentEntity.builder()
+            .roomId(10L)
             .messageId(1L)
             .uploaderId(2L)
             .metadata(new FileMetadataEmbeddable(
@@ -53,6 +54,7 @@ public class FileAttachmentJpaRepositoryTest extends IntegrationTestSupport {
 
         // then
         assertThat(savedEntity.getId()).isNotNull();
+        assertThat(savedEntity.getRoomId()).isEqualTo(10L);
         assertThat(savedEntity.getMessageId()).isEqualTo(1L);
         assertThat(savedEntity.getUploaderId()).isEqualTo(2L);
         assertThat(savedEntity.getFileType()).isEqualTo(FileType.IMAGE);
@@ -70,6 +72,7 @@ public class FileAttachmentJpaRepositoryTest extends IntegrationTestSupport {
         void should_findByMessageId_when_validMessageId() {
             // given
             FileAttachmentEntity fileAttachmentEntity = FileAttachmentEntity.builder()
+                .roomId(10L)
                 .messageId(1L)
                 .uploaderId(2L)
                 .metadata(new FileMetadataEmbeddable(
@@ -96,6 +99,7 @@ public class FileAttachmentJpaRepositoryTest extends IntegrationTestSupport {
 
             // then
             assertThat(foundEntity.getId()).isNotNull();
+            assertThat(foundEntity.getRoomId()).isEqualTo(10L);
             assertThat(foundEntity.getMessageId()).isEqualTo(1L);
             assertThat(foundEntity.getUploaderId()).isEqualTo(2L);
             assertThat(foundEntity.getFileType()).isEqualTo(FileType.IMAGE);

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentMapperTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentMapperTest.java
@@ -56,6 +56,7 @@ class FileAttachmentMapperTest {
 
             FileAttachmentEntity entity = FileAttachmentEntity.builder()
                     .id(1L)
+                    .roomId(10L)
                     .messageId(100L)
                     .uploaderId(50L)
                     .metadata(metadataEmbeddable)
@@ -71,6 +72,7 @@ class FileAttachmentMapperTest {
 
             // then
             assertThat(domain.id()).isEqualTo(1L);
+            assertThat(domain.roomId()).isEqualTo(10L);
             assertThat(domain.messageId()).isEqualTo(100L);
             assertThat(domain.uploaderId()).isEqualTo(50L);
             assertThat(domain.fileType()).isEqualTo(FileType.IMAGE);
@@ -120,6 +122,7 @@ class FileAttachmentMapperTest {
 
             FileAttachmentEntity entity = FileAttachmentEntity.builder()
                     .id(1L)
+                    .roomId(10L)
                     .messageId(100L)
                     .uploaderId(50L)
                     .metadata(metadataEmbeddable)
@@ -169,6 +172,7 @@ class FileAttachmentMapperTest {
 
             FileAttachment domain = FileAttachment.reconstruct(
                     1L,
+                    10L,
                     100L,
                     50L,
                     metadata,
@@ -184,6 +188,7 @@ class FileAttachmentMapperTest {
 
             // then
             assertThat(entity.getId()).isEqualTo(1L);
+            assertThat(entity.getRoomId()).isEqualTo(10L);
             assertThat(entity.getMessageId()).isEqualTo(100L);
             assertThat(entity.getUploaderId()).isEqualTo(50L);
             assertThat(entity.getFileType()).isEqualTo(FileType.VIDEO);
@@ -226,6 +231,7 @@ class FileAttachmentMapperTest {
 
             FileAttachment domain = FileAttachment.reconstruct(
                     1L,
+                    10L,
                     100L,
                     50L,
                     metadata,
@@ -273,6 +279,7 @@ class FileAttachmentMapperTest {
 
             FileAttachment original = FileAttachment.reconstruct(
                     1L,
+                    10L,
                     100L,
                     50L,
                     originalMetadata,
@@ -289,6 +296,7 @@ class FileAttachmentMapperTest {
 
             // then
             assertThat(converted.id()).isEqualTo(original.id());
+            assertThat(converted.roomId()).isEqualTo(original.roomId());
             assertThat(converted.messageId()).isEqualTo(original.messageId());
             assertThat(converted.uploaderId()).isEqualTo(original.uploaderId());
             assertThat(converted.fileType()).isEqualTo(original.fileType());
@@ -349,6 +357,7 @@ class FileAttachmentMapperTest {
 
             FileAttachment original = FileAttachment.reconstruct(
                     1L,
+                    10L,
                     100L,
                     50L,
                     metadata,

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/security/filter/JwtAuthenticationFilterTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/security/filter/JwtAuthenticationFilterTest.java
@@ -7,7 +7,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.mockito.BDDMockito.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -22,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 
-import com.lrchan.qootalk.common.exception.InfrastructureException;
 import com.lrchan.qootalk.infrastructure.security.provider.JwtAuthenticationValidator;
 
 import jakarta.servlet.FilterChain;


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #77 
## 📝작업 내용
- **QuerydslConfig 추가**: Querydsl을 사용하기 위한 설정 파일을 추가
- **파일 업로드 유스케이스 정의 및 구현**: `UploadFileAttachmentCommand`와 `UploadFileAttachmentUsecase`를 통해 파일 업로드 기능을 구현하였습니다.
- **채팅방 첨부 파일 조회 유스케이스 로직 구현**: `LoadFileAttachmentsCommand`와 `LoadFileAttachmentsUsecase`를 통해 특정 방의 첨부 파일을 조회하는 기능을 추가하였습니다.
- 채팅방 첨부파일 조회 페이징 쿼리를 querydsl을 사용하여 db 접근을 용이하게 하였습니다.
  - 동적 페이징 쿼리와 count 쿼리를 분리하여 데이터 정합성을 높였습니다.
- **파일 삭제 유스케이스 정의 및 구현**: `DeleteFileAttachmentCommand`와 `DeleteFileAttachmentUsecase`를 통해 파일 삭제 기능을 구현하였습니다.


- **단위 테스트 추가**: 첨부파일 유스케이스 서비스에 대한 단위 테스트를 추가하였습니다.

