### PR TITLE
feat: module-presentation API 컨트롤러 및 문서화 추가

### DIFF
--- a/qootalk-server/docs/api-spec/README.md
+++ b/qootalk-server/docs/api-spec/README.md
@@ -37,6 +37,10 @@
 }
 ```
 
+## 날짜/시간 형식
+
+- `LocalDateTime` 응답은 오프셋 없이 `yyyy-MM-ddTHH:mm:ss` 형식을 사용합니다.
+
 ## API 목록
 
 | # | Method | Path | 설명 | 명세 |

--- a/qootalk-server/docs/api-spec/auth/01-signup.md
+++ b/qootalk-server/docs/api-spec/auth/01-signup.md
@@ -26,10 +26,9 @@
     "profileImageUrl": null,
     "statusMessage": "",
     "role": "USER",
-    "status": "ACTIVE",
-    "emailVerified": false,
-    "createdAt": "2026-03-12T10:00:00+09:00",
-    "updatedAt": "2026-03-12T10:00:00+09:00"
+    "createdAt": "2026-03-12T10:00:00",
+    "updatedAt": "2026-03-12T10:00:00",
+    "deletedAt": null
   },
   "error": null
 }

--- a/qootalk-server/docs/api-spec/auth/02-login.md
+++ b/qootalk-server/docs/api-spec/auth/02-login.md
@@ -23,16 +23,20 @@
       "id": 1,
       "email": "user@qootalk.com",
       "name": "홍길동",
+      "profileImageUrl": null,
+      "statusMessage": "",
       "role": "USER",
-      "status": "ACTIVE"
+      "createdAt": "2026-03-12T10:00:00",
+      "updatedAt": "2026-03-12T10:00:00",
+      "deletedAt": null
     },
     "token": {
       "accessToken": {
-        "value": "eyJhbGciOiJIUzI1NiJ9...",
+        "token": "eyJhbGciOiJIUzI1NiJ9...",
         "expiresIn": 3600000
       },
       "refreshToken": {
-        "value": "eyJhbGciOiJIUzI1NiJ9...",
+        "token": "eyJhbGciOiJIUzI1NiJ9...",
         "expiresIn": 1209600000
       }
     }

--- a/qootalk-server/docs/api-spec/auth/04-refresh-token.md
+++ b/qootalk-server/docs/api-spec/auth/04-refresh-token.md
@@ -17,11 +17,11 @@
   "success": true,
   "data": {
     "accessToken": {
-      "value": "eyJhbGciOiJIUzI1NiJ9...",
+      "token": "eyJhbGciOiJIUzI1NiJ9...",
       "expiresIn": 3600000
     },
     "refreshToken": {
-      "value": "eyJhbGciOiJIUzI1NiJ9...",
+      "token": "eyJhbGciOiJIUzI1NiJ9...",
       "expiresIn": 1209600000
     }
   },

--- a/qootalk-server/docs/api-spec/chat-room/01-create-chat-room.md
+++ b/qootalk-server/docs/api-spec/chat-room/01-create-chat-room.md
@@ -26,7 +26,7 @@
     "roomType": "GROUP",
     "createdBy": 1,
     "participantCount": 3,
-    "createdAt": "2026-03-12T11:00:00+09:00"
+    "createdAt": "2026-03-12T11:00:00"
   },
   "error": null
 }

--- a/qootalk-server/docs/api-spec/chat-room/02-get-chat-rooms.md
+++ b/qootalk-server/docs/api-spec/chat-room/02-get-chat-rooms.md
@@ -25,7 +25,7 @@
         "roomType": "GROUP",
         "lastMessage": "오늘 배포 일정 공유드립니다.",
         "unreadCount": 3,
-        "updatedAt": "2026-03-12T11:05:00+09:00"
+        "updatedAt": "2026-03-12T11:05:00"
       }
     ],
     "page": 0,

--- a/qootalk-server/docs/api-spec/chat-room/03-get-chat-room-detail.md
+++ b/qootalk-server/docs/api-spec/chat-room/03-get-chat-room-detail.md
@@ -18,11 +18,11 @@
       {
         "userId": 1,
         "roomRole": "OWNER",
-        "joinedAt": "2026-03-12T11:00:00+09:00"
+        "joinedAt": "2026-03-12T11:00:00"
       }
     ],
     "notificationEnabled": true,
-    "createdAt": "2026-03-12T11:00:00+09:00"
+    "createdAt": "2026-03-12T11:00:00"
   },
   "error": null
 }

--- a/qootalk-server/docs/api-spec/chat-room/04-update-chat-room.md
+++ b/qootalk-server/docs/api-spec/chat-room/04-update-chat-room.md
@@ -20,7 +20,7 @@
   "data": {
     "id": 10,
     "roomName": "백엔드 플랫폼 팀",
-    "updatedAt": "2026-03-12T11:10:00+09:00"
+    "updatedAt": "2026-03-12T11:10:00"
   },
   "error": null
 }

--- a/qootalk-server/docs/api-spec/chat-room/05-delete-chat-room.md
+++ b/qootalk-server/docs/api-spec/chat-room/05-delete-chat-room.md
@@ -10,8 +10,9 @@
 {
   "success": true,
   "data": {
-    "deleted": true,
-    "roomId": 10
+    "id": 10,
+    "roomName": "백엔드 팀",
+    "deletedAt": "2026-03-12T11:15:00"
   },
   "error": null
 }

--- a/qootalk-server/docs/api-spec/file/01-upload-file.md
+++ b/qootalk-server/docs/api-spec/file/01-upload-file.md
@@ -20,14 +20,21 @@
     "id": 501,
     "messageId": 1001,
     "uploaderId": 1,
-    "fileName": "architecture.pdf",
+    "fileName": {
+      "value": "architecture.pdf"
+    },
     "fileType": "DOCUMENT",
-    "contentType": "application/pdf",
-    "fileSize": 102400,
-    "storageType": "S3",
-    "path": "chat/10/2026/03/architecture.pdf",
-    "downloadUrl": "https://cdn.qootalk.com/files/501",
-    "createdAt": "2026-03-12T11:40:00+09:00"
+    "contentType": {
+      "value": "application/pdf"
+    },
+    "fileSize": {
+      "value": 102400
+    },
+    "storageType": "LOCAL",
+    "storagePath": {
+      "value": "uploads/chat/10/attachments/1001/"
+    },
+    "createdAt": "2026-03-12T11:40:00"
   },
   "error": null
 }

--- a/qootalk-server/docs/api-spec/file/02-get-files.md
+++ b/qootalk-server/docs/api-spec/file/02-get-files.md
@@ -21,11 +21,23 @@
     "content": [
       {
         "id": 501,
-        "fileName": "architecture.pdf",
-        "fileType": "DOCUMENT",
-        "fileSize": 102400,
+        "messageId": 1001,
         "uploaderId": 1,
-        "createdAt": "2026-03-12T11:40:00+09:00"
+        "fileName": {
+          "value": "architecture.pdf"
+        },
+        "fileType": "DOCUMENT",
+        "contentType": {
+          "value": "application/pdf"
+        },
+        "fileSize": {
+          "value": 102400
+        },
+        "storageType": "LOCAL",
+        "storagePath": {
+          "value": "uploads/chat/10/attachments/1001/"
+        },
+        "createdAt": "2026-03-12T11:40:00"
       }
     ],
     "page": 0,

--- a/qootalk-server/docs/api-spec/file/04-delete-file.md
+++ b/qootalk-server/docs/api-spec/file/04-delete-file.md
@@ -10,8 +10,8 @@
 {
   "success": true,
   "data": {
-    "deleted": true,
-    "fileId": 501
+    "id": 501,
+    "deletedAt": "2026-03-12T11:45:00"
   },
   "error": null
 }

--- a/qootalk-server/docs/api-spec/member/01-get-my-profile.md
+++ b/qootalk-server/docs/api-spec/member/01-get-my-profile.md
@@ -16,11 +16,9 @@
     "profileImageUrl": "https://cdn.qootalk.com/profiles/1.png",
     "statusMessage": "회의 중",
     "role": "USER",
-    "status": "ACTIVE",
-    "emailVerified": true,
-    "lastLoginAt": "2026-03-12T09:00:00+09:00",
-    "createdAt": "2026-03-01T10:00:00+09:00",
-    "updatedAt": "2026-03-12T10:00:00+09:00"
+    "createdAt": "2026-03-01T10:00:00",
+    "updatedAt": "2026-03-12T10:00:00",
+    "deletedAt": null
   },
   "error": null
 }

--- a/qootalk-server/docs/api-spec/member/02-update-my-profile.md
+++ b/qootalk-server/docs/api-spec/member/02-update-my-profile.md
@@ -21,10 +21,14 @@
   "success": true,
   "data": {
     "id": 1,
+    "email": "user@qootalk.com",
     "name": "김쿠톡",
-    "statusMessage": "업무 집중",
     "profileImageUrl": "https://cdn.qootalk.com/profiles/1-new.png",
-    "updatedAt": "2026-03-12T10:10:00+09:00"
+    "statusMessage": "업무 집중",
+    "role": "USER",
+    "createdAt": "2026-03-01T10:00:00",
+    "updatedAt": "2026-03-12T10:10:00",
+    "deletedAt": null
   },
   "error": null
 }

--- a/qootalk-server/docs/api-spec/message/01-send-message.md
+++ b/qootalk-server/docs/api-spec/message/01-send-message.md
@@ -29,9 +29,8 @@
     "messageType": "TEXT",
     "mentions": [12, 15],
     "parentMessageId": null,
-    "attachments": [],
-    "readCount": 0,
-    "createdAt": "2026-03-12T11:20:00+09:00"
+    "attachmentIds": [],
+    "createdAt": "2026-03-12T11:20:00"
   },
   "error": null
 }

--- a/qootalk-server/module-common/src/main/java/com/lrchan/qootalk/common/response/ApiResponse.java
+++ b/qootalk-server/module-common/src/main/java/com/lrchan/qootalk/common/response/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.lrchan.qootalk.common.response;
+
+import com.lrchan.qootalk.common.error.ErrorCode;
+
+public record ApiResponse<T>(
+    boolean success,
+    T data,
+    ErrorResponse error
+) {
+    public static <T> ApiResponse<T> of(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<Void> of(ErrorCode error) {
+        return new ApiResponse<>(false, null, ErrorResponse.of(error));
+    }
+
+    public record ErrorResponse(
+        String code,
+        String message
+    ) {
+        public static ErrorResponse of(ErrorCode error) {
+            return new ErrorResponse(error.getCode(), error.getMessage());
+        }
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/filter/JwtAuthenticationFilter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/security/filter/JwtAuthenticationFilter.java
@@ -24,6 +24,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = jwtAuthenticationValidator.resolveToken(request);
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         jwtAuthenticationValidator.validateToken(token);
         

--- a/qootalk-server/module-presentation/build.gradle
+++ b/qootalk-server/module-presentation/build.gradle
@@ -24,9 +24,9 @@ dependencies {
 
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
 
 	// Flyway
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
 }
-

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatRoomController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.lrchan.qootalk.presentation.api.chat.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,8 +14,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.lrchan.qootalk.application.chat.dto.result.CreateChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.dto.result.ChatRoomDetailQueryResult;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.dto.result.UpdateChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.port.in.CreateChatRoomUsecase;
+import com.lrchan.qootalk.application.chat.port.in.DeleteChatRoomUsecase;
 import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomDetailUsecase;
 import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomsUsecase;
 import com.lrchan.qootalk.application.chat.port.in.UpdateChatRoomUsecase;
@@ -23,6 +26,7 @@ import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.request.CreateChatRoomRequest;
 import com.lrchan.qootalk.presentation.api.chat.dto.request.UpdateChatRoomRequest;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.ChatRoomDetailResponse;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.DeleteChatRoomResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.CreateChatRoomResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.ChatRoomSummaryResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.UpdateChatRoomResponse;
@@ -40,6 +44,7 @@ public class ChatRoomController {
 
     private final AuthenticatedUserProvider authenticatedUserProvider;
     private final CreateChatRoomUsecase createChatRoomUsecase;
+    private final DeleteChatRoomUsecase deleteChatRoomUsecase;
     private final LoadChatRoomDetailUsecase loadChatRoomDetailUsecase;
     private final LoadChatRoomsUsecase loadChatRoomsUsecase;
     private final UpdateChatRoomUsecase updateChatRoomUsecase;
@@ -105,5 +110,18 @@ public class ChatRoomController {
         Long requesterId = authenticatedUserProvider.getCurrentUserId();
         UpdateChatRoomQueryResult result = updateChatRoomUsecase.update(request.toCommand(requesterId, roomId));
         return ResponseEntity.ok(ApiResponse.of(UpdateChatRoomResponse.of(result)));
+    }
+
+    @DeleteMapping("/{roomId}")
+    @Operation(
+        summary = "채팅방 삭제",
+        description = "현재 로그인한 사용자가 채팅방을 삭제합니다."
+    )
+    public ResponseEntity<ApiResponse<DeleteChatRoomResponse>> deleteChatRoom(@PathVariable Long roomId) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        DeleteChatRoomQueryResult result = deleteChatRoomUsecase.delete(
+            new com.lrchan.qootalk.application.chat.dto.command.DeleteChatRoomCommand(requesterId, roomId)
+        );
+        return ResponseEntity.ok(ApiResponse.of(DeleteChatRoomResponse.of(result)));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatRoomController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatRoomController.java
@@ -2,6 +2,7 @@ package com.lrchan.qootalk.presentation.api.chat.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,11 +11,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import com.lrchan.qootalk.application.chat.dto.result.CreateChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomDetailQueryResult;
 import com.lrchan.qootalk.application.chat.port.in.CreateChatRoomUsecase;
+import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomDetailUsecase;
 import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomsUsecase;
 import com.lrchan.qootalk.common.response.ApiResponse;
 import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.request.CreateChatRoomRequest;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.ChatRoomDetailResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.CreateChatRoomResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.ChatRoomSummaryResponse;
 import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
@@ -31,6 +35,7 @@ public class ChatRoomController {
 
     private final AuthenticatedUserProvider authenticatedUserProvider;
     private final CreateChatRoomUsecase createChatRoomUsecase;
+    private final LoadChatRoomDetailUsecase loadChatRoomDetailUsecase;
     private final LoadChatRoomsUsecase loadChatRoomsUsecase;
 
     @PostMapping
@@ -67,5 +72,18 @@ public class ChatRoomController {
             result.totalPages()
         );
         return ResponseEntity.ok(ApiResponse.of(response));
+    }
+
+    @GetMapping("/{roomId}")
+    @Operation(
+        summary = "채팅방 상세 조회",
+        description = "현재 로그인한 사용자가 참여 중인 채팅방 상세 정보를 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<ChatRoomDetailResponse>> getChatRoomDetail(@PathVariable Long roomId) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        ChatRoomDetailQueryResult result = loadChatRoomDetailUsecase.load(
+            new com.lrchan.qootalk.application.chat.dto.command.LoadChatRoomDetailCommand(requesterId, roomId)
+        );
+        return ResponseEntity.ok(ApiResponse.of(ChatRoomDetailResponse.of(result)));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatRoomController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatRoomController.java
@@ -1,0 +1,41 @@
+package com.lrchan.qootalk.presentation.api.chat.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lrchan.qootalk.application.chat.dto.result.CreateChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.CreateChatRoomUsecase;
+import com.lrchan.qootalk.common.response.ApiResponse;
+import com.lrchan.qootalk.presentation.api.chat.dto.request.CreateChatRoomRequest;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.CreateChatRoomResponse;
+import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/chat-rooms")
+@RequiredArgsConstructor
+@Tag(name = "Chat Room", description = "채팅방 API")
+public class ChatRoomController {
+
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final CreateChatRoomUsecase createChatRoomUsecase;
+
+    @PostMapping
+    @Operation(
+        summary = "채팅방 생성",
+        description = "현재 로그인한 사용자가 새 채팅방을 생성합니다."
+    )
+    public ResponseEntity<ApiResponse<CreateChatRoomResponse>> createChatRoom(
+        @RequestBody CreateChatRoomRequest request
+    ) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        CreateChatRoomQueryResult result = createChatRoomUsecase.create(request.toCommand(requesterId));
+        return ResponseEntity.ok(ApiResponse.of(CreateChatRoomResponse.of(result)));
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatRoomController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatRoomController.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,15 +13,19 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.lrchan.qootalk.application.chat.dto.result.CreateChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.dto.result.ChatRoomDetailQueryResult;
+import com.lrchan.qootalk.application.chat.dto.result.UpdateChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.port.in.CreateChatRoomUsecase;
 import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomDetailUsecase;
 import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomsUsecase;
+import com.lrchan.qootalk.application.chat.port.in.UpdateChatRoomUsecase;
 import com.lrchan.qootalk.common.response.ApiResponse;
 import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.request.CreateChatRoomRequest;
+import com.lrchan.qootalk.presentation.api.chat.dto.request.UpdateChatRoomRequest;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.ChatRoomDetailResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.CreateChatRoomResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.ChatRoomSummaryResponse;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.UpdateChatRoomResponse;
 import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,6 +42,7 @@ public class ChatRoomController {
     private final CreateChatRoomUsecase createChatRoomUsecase;
     private final LoadChatRoomDetailUsecase loadChatRoomDetailUsecase;
     private final LoadChatRoomsUsecase loadChatRoomsUsecase;
+    private final UpdateChatRoomUsecase updateChatRoomUsecase;
 
     @PostMapping
     @Operation(
@@ -85,5 +91,19 @@ public class ChatRoomController {
             new com.lrchan.qootalk.application.chat.dto.command.LoadChatRoomDetailCommand(requesterId, roomId)
         );
         return ResponseEntity.ok(ApiResponse.of(ChatRoomDetailResponse.of(result)));
+    }
+
+    @PatchMapping("/{roomId}")
+    @Operation(
+        summary = "채팅방 수정",
+        description = "현재 로그인한 사용자가 참여 중인 채팅방 이름을 수정합니다."
+    )
+    public ResponseEntity<ApiResponse<UpdateChatRoomResponse>> updateChatRoom(
+        @PathVariable Long roomId,
+        @RequestBody UpdateChatRoomRequest request
+    ) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        UpdateChatRoomQueryResult result = updateChatRoomUsecase.update(request.toCommand(requesterId, roomId));
+        return ResponseEntity.ok(ApiResponse.of(UpdateChatRoomResponse.of(result)));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatRoomController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatRoomController.java
@@ -1,16 +1,22 @@
 package com.lrchan.qootalk.presentation.api.chat.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.lrchan.qootalk.application.chat.dto.result.CreateChatRoomQueryResult;
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
 import com.lrchan.qootalk.application.chat.port.in.CreateChatRoomUsecase;
+import com.lrchan.qootalk.application.chat.port.in.LoadChatRoomsUsecase;
 import com.lrchan.qootalk.common.response.ApiResponse;
+import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.request.CreateChatRoomRequest;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.CreateChatRoomResponse;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.ChatRoomSummaryResponse;
 import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +31,7 @@ public class ChatRoomController {
 
     private final AuthenticatedUserProvider authenticatedUserProvider;
     private final CreateChatRoomUsecase createChatRoomUsecase;
+    private final LoadChatRoomsUsecase loadChatRoomsUsecase;
 
     @PostMapping
     @Operation(
@@ -37,5 +44,28 @@ public class ChatRoomController {
         Long requesterId = authenticatedUserProvider.getCurrentUserId();
         CreateChatRoomQueryResult result = createChatRoomUsecase.create(request.toCommand(requesterId));
         return ResponseEntity.ok(ApiResponse.of(CreateChatRoomResponse.of(result)));
+    }
+
+    @GetMapping
+    @Operation(
+        summary = "채팅방 목록 조회",
+        description = "현재 로그인한 사용자가 참여 중인 채팅방 목록을 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<PagedResponse<ChatRoomSummaryResponse>>> getChatRooms(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        PagedResponse<ChatRoomQueryResult> result = loadChatRoomsUsecase.load(
+            new com.lrchan.qootalk.application.chat.dto.command.LoadChatRoomsCommand(requesterId, page, size)
+        );
+        PagedResponse<ChatRoomSummaryResponse> response = PagedResponse.of(
+            result.content().stream().map(ChatRoomSummaryResponse::of).toList(),
+            result.page(),
+            result.size(),
+            result.totalElements(),
+            result.totalPages()
+        );
+        return ResponseEntity.ok(ApiResponse.of(response));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/FileController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/FileController.java
@@ -1,0 +1,55 @@
+package com.lrchan.qootalk.presentation.api.chat.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.lrchan.qootalk.application.chat.dto.command.UploadFileAttachmentCommand;
+import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.UploadFileAttachmentUsecase;
+import com.lrchan.qootalk.common.response.ApiResponse;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.FileAttachmentResponse;
+import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/files")
+@RequiredArgsConstructor
+@Tag(name = "File", description = "파일 API")
+public class FileController {
+
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final UploadFileAttachmentUsecase uploadFileAttachmentUsecase;
+
+    @PostMapping(consumes = "multipart/form-data")
+    @Operation(
+        summary = "파일 업로드",
+        description = "현재 로그인한 사용자가 채팅방에 파일을 업로드합니다."
+    )
+    public ResponseEntity<ApiResponse<FileAttachmentResponse>> uploadFile(
+        @RequestParam Long roomId,
+        @RequestParam(required = false) Long messageId,
+        @RequestPart("file") MultipartFile file
+    ) throws Exception {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        FileAttachmentQueryResult result = uploadFileAttachmentUsecase.upload(
+            new UploadFileAttachmentCommand(
+                requesterId,
+                roomId,
+                messageId,
+                file.getInputStream(),
+                file.getOriginalFilename(),
+                file.getContentType(),
+                file.getSize()
+            )
+        );
+        return ResponseEntity.ok(ApiResponse.of(FileAttachmentResponse.of(result)));
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/FileController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/FileController.java
@@ -1,19 +1,23 @@
 package com.lrchan.qootalk.presentation.api.chat.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.lrchan.qootalk.application.chat.dto.command.UploadFileAttachmentCommand;
 import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
+import com.lrchan.qootalk.application.chat.dto.command.UploadFileAttachmentCommand;
+import com.lrchan.qootalk.application.chat.port.in.LoadFileAttachmentsUsecase;
 import com.lrchan.qootalk.application.chat.port.in.UploadFileAttachmentUsecase;
 import com.lrchan.qootalk.common.response.ApiResponse;
+import com.lrchan.qootalk.common.response.PagedResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.FileAttachmentResponse;
 import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class FileController {
 
     private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final LoadFileAttachmentsUsecase loadFileAttachmentsUsecase;
     private final UploadFileAttachmentUsecase uploadFileAttachmentUsecase;
 
     @PostMapping(consumes = "multipart/form-data")
@@ -51,5 +56,38 @@ public class FileController {
             )
         );
         return ResponseEntity.ok(ApiResponse.of(FileAttachmentResponse.of(result)));
+    }
+
+    @GetMapping
+    @Operation(
+        summary = "파일 목록 조회",
+        description = "현재 로그인한 사용자가 접근 가능한 채팅방 파일 목록을 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<PagedResponse<FileAttachmentResponse>>> getFiles(
+        @RequestParam Long roomId,
+        @RequestParam(required = false) Long uploaderId,
+        @RequestParam(required = false) FileType fileType,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        PagedResponse<FileAttachmentQueryResult> result = loadFileAttachmentsUsecase.load(
+            new com.lrchan.qootalk.application.chat.dto.command.LoadFileAttachmentsCommand(
+                requesterId,
+                roomId,
+                uploaderId,
+                fileType,
+                page,
+                size
+            )
+        );
+        PagedResponse<FileAttachmentResponse> response = PagedResponse.of(
+            result.content().stream().map(FileAttachmentResponse::of).toList(),
+            result.page(),
+            result.size(),
+            result.totalElements(),
+            result.totalPages()
+        );
+        return ResponseEntity.ok(ApiResponse.of(response));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/FileController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/FileController.java
@@ -1,7 +1,9 @@
 package com.lrchan.qootalk.presentation.api.chat.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,11 +12,14 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteFileAttachmentQueryResult;
 import com.lrchan.qootalk.application.chat.dto.command.UploadFileAttachmentCommand;
+import com.lrchan.qootalk.application.chat.port.in.DeleteFileAttachmentUsecase;
 import com.lrchan.qootalk.application.chat.port.in.LoadFileAttachmentsUsecase;
 import com.lrchan.qootalk.application.chat.port.in.UploadFileAttachmentUsecase;
 import com.lrchan.qootalk.common.response.ApiResponse;
 import com.lrchan.qootalk.common.response.PagedResponse;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.DeleteFileAttachmentResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.FileAttachmentResponse;
 import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
 import com.lrchan.qootalk.domain.chat.attachment.FileType;
@@ -30,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 public class FileController {
 
     private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final DeleteFileAttachmentUsecase deleteFileAttachmentUsecase;
     private final LoadFileAttachmentsUsecase loadFileAttachmentsUsecase;
     private final UploadFileAttachmentUsecase uploadFileAttachmentUsecase;
 
@@ -89,5 +95,21 @@ public class FileController {
             result.totalPages()
         );
         return ResponseEntity.ok(ApiResponse.of(response));
+    }
+
+    @DeleteMapping("/{fileId}")
+    @Operation(
+        summary = "파일 삭제",
+        description = "현재 로그인한 사용자가 채팅방 파일을 삭제합니다."
+    )
+    public ResponseEntity<ApiResponse<DeleteFileAttachmentResponse>> deleteFile(
+        @PathVariable Long fileId,
+        @RequestParam Long roomId
+    ) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        DeleteFileAttachmentQueryResult result = deleteFileAttachmentUsecase.delete(
+            new com.lrchan.qootalk.application.chat.dto.command.DeleteFileAttachmentCommand(requesterId, roomId, fileId)
+        );
+        return ResponseEntity.ok(ApiResponse.of(DeleteFileAttachmentResponse.of(result)));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/request/CreateChatRoomRequest.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/request/CreateChatRoomRequest.java
@@ -1,0 +1,24 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.request;
+
+import java.util.List;
+
+import com.lrchan.qootalk.application.chat.dto.command.CreateChatRoomCommand;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 생성 요청")
+public record CreateChatRoomRequest(
+    @Schema(description = "채팅방 이름", example = "백엔드 팀")
+    String roomName,
+    @Schema(description = "채팅방 타입", example = "GROUP")
+    RoomType roomType,
+    @Schema(description = "참여자 사용자 ID 목록", example = "[1, 2, 3]")
+    List<Long> participantIds,
+    @Schema(description = "알림 활성화 여부", example = "true")
+    boolean notificationEnabled
+) {
+    public CreateChatRoomCommand toCommand(Long requesterId) {
+        return new CreateChatRoomCommand(requesterId, roomName, roomType, participantIds, notificationEnabled);
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/request/UpdateChatRoomRequest.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/request/UpdateChatRoomRequest.java
@@ -1,0 +1,15 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.request;
+
+import com.lrchan.qootalk.application.chat.dto.command.UpdateChatRoomCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 수정 요청")
+public record UpdateChatRoomRequest(
+    @Schema(description = "변경할 채팅방 이름", example = "백엔드 플랫폼 팀")
+    String roomName
+) {
+    public UpdateChatRoomCommand toCommand(Long requesterId, Long roomId) {
+        return new UpdateChatRoomCommand(requesterId, roomId, roomName);
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/ChatRoomDetailResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/ChatRoomDetailResponse.java
@@ -1,0 +1,39 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomDetailQueryResult;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 상세 응답")
+public record ChatRoomDetailResponse(
+    @Schema(description = "채팅방 ID", example = "10")
+    Long id,
+    @Schema(description = "채팅방 이름", example = "백엔드 팀")
+    String roomName,
+    @Schema(description = "채팅방 타입", example = "GROUP")
+    RoomType roomType,
+    @Schema(description = "생성자 사용자 ID", example = "1")
+    Long createdBy,
+    @Schema(description = "참여자 목록")
+    List<ChatRoomParticipantResponse> participants,
+    @Schema(description = "알림 활성화 여부", example = "true")
+    boolean notificationEnabled,
+    @Schema(description = "생성 일시", example = "2026-03-12T11:00:00")
+    LocalDateTime createdAt
+) {
+    public static ChatRoomDetailResponse of(ChatRoomDetailQueryResult result) {
+        return new ChatRoomDetailResponse(
+            result.id(),
+            result.roomName(),
+            result.roomType(),
+            result.createdBy(),
+            result.participants().stream().map(ChatRoomParticipantResponse::of).toList(),
+            result.notificationEnabled(),
+            result.createdAt()
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/ChatRoomParticipantResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/ChatRoomParticipantResponse.java
@@ -1,0 +1,22 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.chat.dto.result.ParticipantResult;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 참여자 응답")
+public record ChatRoomParticipantResponse(
+    @Schema(description = "사용자 ID", example = "1")
+    Long userId,
+    @Schema(description = "방 역할", example = "OWNER")
+    RoomRole roomRole,
+    @Schema(description = "참여 일시", example = "2026-03-12T11:00:00")
+    LocalDateTime joinedAt
+) {
+    public static ChatRoomParticipantResponse of(ParticipantResult result) {
+        return new ChatRoomParticipantResponse(result.userId(), result.roomRole(), result.joinedAt());
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/ChatRoomSummaryResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/ChatRoomSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.chat.dto.result.ChatRoomQueryResult;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 목록 항목 응답")
+public record ChatRoomSummaryResponse(
+    @Schema(description = "채팅방 ID", example = "10")
+    Long id,
+    @Schema(description = "채팅방 이름", example = "백엔드 팀")
+    String roomName,
+    @Schema(description = "채팅방 타입", example = "GROUP")
+    RoomType roomType,
+    @Schema(description = "마지막 메시지", example = "오늘 배포 일정 공유드립니다.")
+    String lastMessage,
+    @Schema(description = "읽지 않은 메시지 수", example = "3")
+    int unreadCount,
+    @Schema(description = "마지막 갱신 일시", example = "2026-03-12T11:05:00")
+    LocalDateTime updatedAt
+) {
+    public static ChatRoomSummaryResponse of(ChatRoomQueryResult result) {
+        return new ChatRoomSummaryResponse(
+            result.id(),
+            result.roomName(),
+            result.roomType(),
+            result.lastMessage(),
+            result.unreadCount(),
+            result.updatedAt()
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/CreateChatRoomResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/CreateChatRoomResponse.java
@@ -1,0 +1,35 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.chat.dto.result.CreateChatRoomQueryResult;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 생성 응답")
+public record CreateChatRoomResponse(
+    @Schema(description = "채팅방 ID", example = "10")
+    Long id,
+    @Schema(description = "채팅방 이름", example = "백엔드 팀")
+    String roomName,
+    @Schema(description = "채팅방 타입", example = "GROUP")
+    RoomType roomType,
+    @Schema(description = "생성자 사용자 ID", example = "1")
+    Long createdBy,
+    @Schema(description = "참여자 수", example = "3")
+    int participantCount,
+    @Schema(description = "생성 일시", example = "2026-03-12T11:00:00")
+    LocalDateTime createdAt
+) {
+    public static CreateChatRoomResponse of(CreateChatRoomQueryResult result) {
+        return new CreateChatRoomResponse(
+            result.id(),
+            result.roomName(),
+            result.roomType(),
+            result.createdBy(),
+            result.participantCount(),
+            result.createdAt()
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/DeleteChatRoomResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/DeleteChatRoomResponse.java
@@ -1,0 +1,21 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.chat.dto.result.DeleteChatRoomQueryResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 삭제 응답")
+public record DeleteChatRoomResponse(
+    @Schema(description = "채팅방 ID", example = "10")
+    Long id,
+    @Schema(description = "삭제된 채팅방 이름", example = "백엔드 팀")
+    String roomName,
+    @Schema(description = "삭제 일시", example = "2026-03-12T11:15:00")
+    LocalDateTime deletedAt
+) {
+    public static DeleteChatRoomResponse of(DeleteChatRoomQueryResult result) {
+        return new DeleteChatRoomResponse(result.id(), result.roomName(), result.deletedAt());
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/DeleteFileAttachmentResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/DeleteFileAttachmentResponse.java
@@ -1,0 +1,19 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.chat.dto.result.DeleteFileAttachmentQueryResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "파일 삭제 응답")
+public record DeleteFileAttachmentResponse(
+    @Schema(description = "파일 ID", example = "501")
+    Long id,
+    @Schema(description = "삭제 일시", example = "2026-03-12T11:45:00")
+    LocalDateTime deletedAt
+) {
+    public static DeleteFileAttachmentResponse of(DeleteFileAttachmentQueryResult result) {
+        return new DeleteFileAttachmentResponse(result.id(), result.deletedAt());
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/FileAttachmentResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/FileAttachmentResponse.java
@@ -1,0 +1,48 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.chat.dto.result.FileAttachmentQueryResult;
+import com.lrchan.qootalk.domain.chat.attachment.FileType;
+import com.lrchan.qootalk.domain.chat.vo.StorageType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "파일 응답")
+public record FileAttachmentResponse(
+    @Schema(description = "파일 ID", example = "501")
+    Long id,
+    @Schema(description = "메시지 ID", example = "1001", nullable = true)
+    Long messageId,
+    @Schema(description = "업로더 사용자 ID", example = "1")
+    Long uploaderId,
+    @Schema(description = "원본 파일명", example = "architecture.pdf")
+    String fileName,
+    @Schema(description = "파일 타입", example = "DOCUMENT")
+    FileType fileType,
+    @Schema(description = "콘텐츠 타입", example = "application/pdf")
+    String contentType,
+    @Schema(description = "파일 크기(bytes)", example = "102400")
+    Long fileSize,
+    @Schema(description = "저장소 타입", example = "LOCAL")
+    StorageType storageType,
+    @Schema(description = "저장 경로", example = "uploads/chat/10/attachments/1001/")
+    String storagePath,
+    @Schema(description = "생성 일시", example = "2026-03-12T11:40:00")
+    LocalDateTime createdAt
+) {
+    public static FileAttachmentResponse of(FileAttachmentQueryResult result) {
+        return new FileAttachmentResponse(
+            result.id(),
+            result.messageId(),
+            result.uploaderId(),
+            result.fileName().value(),
+            result.fileType(),
+            result.contentType().value(),
+            result.fileSize().value(),
+            result.storageType(),
+            result.storagePath().value(),
+            result.createdAt()
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/UpdateChatRoomResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/UpdateChatRoomResponse.java
@@ -1,0 +1,21 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.chat.dto.result.UpdateChatRoomQueryResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 수정 응답")
+public record UpdateChatRoomResponse(
+    @Schema(description = "채팅방 ID", example = "10")
+    Long id,
+    @Schema(description = "수정된 채팅방 이름", example = "백엔드 플랫폼 팀")
+    String roomName,
+    @Schema(description = "수정 일시", example = "2026-03-12T11:10:00")
+    LocalDateTime updatedAt
+) {
+    public static UpdateChatRoomResponse of(UpdateChatRoomQueryResult result) {
+        return new UpdateChatRoomResponse(result.id(), result.roomName(), result.updatedAt());
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/controller/AuthController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/controller/AuthController.java
@@ -1,0 +1,36 @@
+package com.lrchan.qootalk.presentation.api.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+import com.lrchan.qootalk.application.user.port.in.RegisterUserUseCase;
+import com.lrchan.qootalk.common.response.ApiResponse;
+import com.lrchan.qootalk.presentation.api.user.dto.request.UserSignupRequest;
+import com.lrchan.qootalk.presentation.api.user.dto.response.UserSignupResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Tag(name = "Auth", description = "인증 API")
+public class AuthController {
+
+    private final RegisterUserUseCase registerUserUseCase;
+
+    @PostMapping("/signup")
+    @Operation(
+        summary = "회원가입",
+        description = "이메일, 비밀번호, 이름으로 새 사용자를 생성합니다."
+    )
+    public ResponseEntity<ApiResponse<UserSignupResponse>> signup(@RequestBody UserSignupRequest request) {
+        UserQueryResult result = registerUserUseCase.register(request.toCommand());
+        return ResponseEntity.ok(ApiResponse.of(UserSignupResponse.of(result)));
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/controller/AuthController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/controller/AuthController.java
@@ -1,19 +1,25 @@
 package com.lrchan.qootalk.presentation.api.user.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.lrchan.qootalk.application.user.dto.result.LoginResult;
 import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+import com.lrchan.qootalk.application.user.port.in.LoginUserUseCase;
 import com.lrchan.qootalk.application.user.port.in.RegisterUserUseCase;
 import com.lrchan.qootalk.common.response.ApiResponse;
+import com.lrchan.qootalk.presentation.api.user.dto.request.UserLoginRequest;
 import com.lrchan.qootalk.presentation.api.user.dto.request.UserSignupRequest;
+import com.lrchan.qootalk.presentation.api.user.dto.response.UserLoginResponse;
 import com.lrchan.qootalk.presentation.api.user.dto.response.UserSignupResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -23,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
     private final RegisterUserUseCase registerUserUseCase;
+    private final LoginUserUseCase loginUserUseCase;
 
     @PostMapping("/signup")
     @Operation(
@@ -32,5 +39,38 @@ public class AuthController {
     public ResponseEntity<ApiResponse<UserSignupResponse>> signup(@RequestBody UserSignupRequest request) {
         UserQueryResult result = registerUserUseCase.register(request.toCommand());
         return ResponseEntity.ok(ApiResponse.of(UserSignupResponse.of(result)));
+    }
+
+    @PostMapping("/login")
+    @Operation(
+        summary = "로그인",
+        description = "이메일, 비밀번호로 사용자를 로그인합니다."
+    )
+    public ResponseEntity<ApiResponse<UserLoginResponse>> login(
+      @RequestBody UserLoginRequest request,
+      HttpServletRequest httpServletRequest
+    ) {
+        LoginResult result = loginUserUseCase.login(request.toCommand());
+
+        ResponseCookie accessCookie = ResponseCookie.from("accessToken", result.token().accessToken().token())
+            .maxAge(result.token().accessToken().expiresIn())
+            .path("/")
+            .secure(true)
+            .httpOnly(true)
+            .sameSite("Lax")
+            .build();
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", result.token().refreshToken().token())
+            .maxAge(result.token().refreshToken().expiresIn())
+            .path("/")
+            .secure(true)
+            .httpOnly(true)
+            .sameSite("Lax")
+            .build();
+
+        return ResponseEntity.ok()
+            .header("Set-Cookie", accessCookie.toString())
+            .header("Set-Cookie", refreshCookie.toString())
+            .body(ApiResponse.of(UserLoginResponse.of(result)));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/controller/UserProfileController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/controller/UserProfileController.java
@@ -1,0 +1,41 @@
+package com.lrchan.qootalk.presentation.api.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+import com.lrchan.qootalk.application.user.port.in.UpdateStatusMessageUsecase;
+import com.lrchan.qootalk.common.response.ApiResponse;
+import com.lrchan.qootalk.presentation.api.user.dto.request.UpdateStatusMessageRequest;
+import com.lrchan.qootalk.presentation.api.user.dto.response.UserProfileResponse;
+import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/users/me")
+@RequiredArgsConstructor
+@Tag(name = "User Profile", description = "사용자 프로필 API")
+public class UserProfileController {
+
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final UpdateStatusMessageUsecase updateStatusMessageUsecase;
+
+    @PatchMapping("/status-message")
+    @Operation(
+        summary = "상태 메시지 수정",
+        description = "현재 로그인한 사용자의 상태 메시지를 수정합니다."
+    )
+    public ResponseEntity<ApiResponse<UserProfileResponse>> updateStatusMessage(
+        @RequestBody UpdateStatusMessageRequest request
+    ) {
+        Long userId = authenticatedUserProvider.getCurrentUserId();
+        UserQueryResult result = updateStatusMessageUsecase.update(request.toCommand(userId));
+        return ResponseEntity.ok(ApiResponse.of(UserProfileResponse.of(result)));
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/controller/UserProfileController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/controller/UserProfileController.java
@@ -1,6 +1,7 @@
 package com.lrchan.qootalk.presentation.api.user.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,9 +11,11 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+import com.lrchan.qootalk.application.user.port.in.DeleteProfileImageUsecase;
 import com.lrchan.qootalk.application.user.port.in.UpdateStatusMessageUsecase;
 import com.lrchan.qootalk.application.user.port.in.UploadProfileImageUsecase;
 import com.lrchan.qootalk.common.response.ApiResponse;
+import com.lrchan.qootalk.presentation.api.user.dto.request.DeleteProfileImageRequest;
 import com.lrchan.qootalk.presentation.api.user.dto.request.UpdateStatusMessageRequest;
 import com.lrchan.qootalk.presentation.api.user.dto.response.UserProfileResponse;
 import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
@@ -28,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class UserProfileController {
 
     private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final DeleteProfileImageUsecase deleteProfileImageUsecase;
     private final UpdateStatusMessageUsecase updateStatusMessageUsecase;
     private final UploadProfileImageUsecase uploadProfileImageUsecase;
 
@@ -62,6 +66,19 @@ public class UserProfileController {
                 file.getSize()
             )
         );
+        return ResponseEntity.ok(ApiResponse.of(UserProfileResponse.of(result)));
+    }
+
+    @DeleteMapping("/profile-image")
+    @Operation(
+        summary = "프로필 이미지 삭제",
+        description = "현재 로그인한 사용자의 프로필 이미지를 삭제합니다."
+    )
+    public ResponseEntity<ApiResponse<UserProfileResponse>> deleteProfileImage(
+        @RequestBody DeleteProfileImageRequest request
+    ) {
+        Long userId = authenticatedUserProvider.getCurrentUserId();
+        UserQueryResult result = deleteProfileImageUsecase.delete(request.toCommand(userId));
         return ResponseEntity.ok(ApiResponse.of(UserProfileResponse.of(result)));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/controller/UserProfileController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/controller/UserProfileController.java
@@ -1,13 +1,17 @@
 package com.lrchan.qootalk.presentation.api.user.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
 import com.lrchan.qootalk.application.user.port.in.UpdateStatusMessageUsecase;
+import com.lrchan.qootalk.application.user.port.in.UploadProfileImageUsecase;
 import com.lrchan.qootalk.common.response.ApiResponse;
 import com.lrchan.qootalk.presentation.api.user.dto.request.UpdateStatusMessageRequest;
 import com.lrchan.qootalk.presentation.api.user.dto.response.UserProfileResponse;
@@ -25,6 +29,7 @@ public class UserProfileController {
 
     private final AuthenticatedUserProvider authenticatedUserProvider;
     private final UpdateStatusMessageUsecase updateStatusMessageUsecase;
+    private final UploadProfileImageUsecase uploadProfileImageUsecase;
 
     @PatchMapping("/status-message")
     @Operation(
@@ -36,6 +41,27 @@ public class UserProfileController {
     ) {
         Long userId = authenticatedUserProvider.getCurrentUserId();
         UserQueryResult result = updateStatusMessageUsecase.update(request.toCommand(userId));
+        return ResponseEntity.ok(ApiResponse.of(UserProfileResponse.of(result)));
+    }
+
+    @PostMapping(value = "/profile-image", consumes = "multipart/form-data")
+    @Operation(
+        summary = "프로필 이미지 업로드",
+        description = "현재 로그인한 사용자의 프로필 이미지를 업로드합니다."
+    )
+    public ResponseEntity<ApiResponse<UserProfileResponse>> uploadProfileImage(
+        @RequestPart("file") MultipartFile file
+    ) throws Exception {
+        Long userId = authenticatedUserProvider.getCurrentUserId();
+        UserQueryResult result = uploadProfileImageUsecase.upload(
+            new com.lrchan.qootalk.application.user.dto.command.UploadProfileImageCommand(
+                userId,
+                file.getInputStream(),
+                file.getOriginalFilename(),
+                file.getContentType(),
+                file.getSize()
+            )
+        );
         return ResponseEntity.ok(ApiResponse.of(UserProfileResponse.of(result)));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/request/DeleteProfileImageRequest.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/request/DeleteProfileImageRequest.java
@@ -1,0 +1,16 @@
+package com.lrchan.qootalk.presentation.api.user.dto.request;
+
+import com.lrchan.qootalk.application.user.dto.command.DeleteProfileImageCommand;
+import com.lrchan.qootalk.domain.user.vo.ProfileImageUrl;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "프로필 이미지 삭제 요청")
+public record DeleteProfileImageRequest(
+    @Schema(description = "삭제할 프로필 이미지 URL", example = "https://cdn.qootalk.com/profiles/1.png")
+    String profileImageUrl
+) {
+    public DeleteProfileImageCommand toCommand(Long userId) {
+        return new DeleteProfileImageCommand(userId, new ProfileImageUrl(profileImageUrl));
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/request/UpdateStatusMessageRequest.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/request/UpdateStatusMessageRequest.java
@@ -1,0 +1,15 @@
+package com.lrchan.qootalk.presentation.api.user.dto.request;
+
+import com.lrchan.qootalk.application.user.dto.command.UpdateStatusMessageCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상태 메시지 수정 요청")
+public record UpdateStatusMessageRequest(
+    @Schema(description = "변경할 상태 메시지", example = "업무 집중")
+    String statusMessage
+) {
+    public UpdateStatusMessageCommand toCommand(Long userId) {
+        return new UpdateStatusMessageCommand(userId, statusMessage);
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/request/UserLoginRequest.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/request/UserLoginRequest.java
@@ -1,0 +1,18 @@
+package com.lrchan.qootalk.presentation.api.user.dto.request;
+
+import com.lrchan.qootalk.application.user.dto.command.LoginUserCommand;
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.Password;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UserLoginRequest(
+    @Schema(description = "사용자 이메일", example = "user@qootalk.com")
+    String email,
+    @Schema(description = "비밀번호", example = "P@ssw0rd!")
+    String password
+) {
+    public LoginUserCommand toCommand() {
+        return new LoginUserCommand(new Email(email), new Password(password));
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/request/UserSignupRequest.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/request/UserSignupRequest.java
@@ -1,0 +1,22 @@
+package com.lrchan.qootalk.presentation.api.user.dto.request;
+
+import com.lrchan.qootalk.application.user.dto.command.RegisterUserCommand;
+import com.lrchan.qootalk.domain.user.vo.Email;
+import com.lrchan.qootalk.domain.user.vo.Password;
+import com.lrchan.qootalk.domain.user.vo.UserName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원가입 요청")
+public record UserSignupRequest(
+    @Schema(description = "사용자 이메일", example = "user@qootalk.com")
+    String email,
+    @Schema(description = "비밀번호", example = "P@ssw0rd!")
+    String password,
+    @Schema(description = "사용자 이름", example = "홍길동")
+    String name
+) {
+    public RegisterUserCommand toCommand() {
+        return new RegisterUserCommand(new Email(email), new Password(password), new UserName(name));
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/response/UserLoginResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/response/UserLoginResponse.java
@@ -1,0 +1,42 @@
+package com.lrchan.qootalk.presentation.api.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.user.dto.result.LoginResult;
+
+public record UserLoginResponse(
+    @Schema(description = "사용자 ID", example = "1")
+    Long id,
+    @Schema(description = "이메일", example = "user@qootalk.com")
+    String email,
+    @Schema(description = "이름", example = "홍길동")
+    String name,
+    @Schema(description = "프로필 이미지 URL", example = "https://cdn.qootalk.com/profiles/1.png", nullable = true)
+    String profileImageUrl,
+    @Schema(description = "상태 메시지", example = "")
+    String statusMessage,
+    @Schema(description = "권한", example = "USER")
+    String role,
+    @Schema(description = "생성 일시", example = "2026-03-12T10:00:00")
+    LocalDateTime createdAt,
+    @Schema(description = "수정 일시", example = "2026-03-12T10:00:00")
+    LocalDateTime updatedAt,
+    @Schema(description = "삭제 일시", example = "null", nullable = true)
+    LocalDateTime deletedAt
+) {
+    public static UserLoginResponse of(LoginResult result) {
+        return new UserLoginResponse(
+            result.user().id(),
+            result.user().email(),
+            result.user().name(),
+            result.user().profileImageUrl(),
+            result.user().statusMessage(),
+            result.user().role(),
+            result.user().createdAt(),
+            result.user().updatedAt(),
+            result.user().deletedAt()
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/response/UserProfileResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,43 @@
+package com.lrchan.qootalk.presentation.api.user.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 프로필 응답")
+public record UserProfileResponse(
+    @Schema(description = "사용자 ID", example = "1")
+    Long id,
+    @Schema(description = "이메일", example = "user@qootalk.com")
+    String email,
+    @Schema(description = "이름", example = "홍길동")
+    String name,
+    @Schema(description = "프로필 이미지 URL", example = "https://cdn.qootalk.com/profiles/1.png", nullable = true)
+    String profileImageUrl,
+    @Schema(description = "상태 메시지", example = "업무 집중")
+    String statusMessage,
+    @Schema(description = "권한", example = "USER")
+    String role,
+    @Schema(description = "생성 일시", example = "2026-03-12T10:00:00")
+    LocalDateTime createdAt,
+    @Schema(description = "수정 일시", example = "2026-03-12T10:10:00")
+    LocalDateTime updatedAt,
+    @Schema(description = "삭제 일시", nullable = true)
+    LocalDateTime deletedAt
+) {
+    public static UserProfileResponse of(UserQueryResult result) {
+        return new UserProfileResponse(
+            result.id(),
+            result.email(),
+            result.name(),
+            result.profileImageUrl(),
+            result.statusMessage(),
+            result.role(),
+            result.createdAt(),
+            result.updatedAt(),
+            result.deletedAt()
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/response/UserSignupResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/user/dto/response/UserSignupResponse.java
@@ -1,0 +1,43 @@
+package com.lrchan.qootalk.presentation.api.user.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원가입 응답 데이터")
+public record UserSignupResponse(
+    @Schema(description = "사용자 ID", example = "1")
+    Long id,
+    @Schema(description = "이메일", example = "user@qootalk.com")
+    String email,
+    @Schema(description = "이름", example = "홍길동")
+    String name,
+    @Schema(description = "프로필 이미지 URL", example = "https://cdn.qootalk.com/profiles/1.png", nullable = true)
+    String profileImageUrl,
+    @Schema(description = "상태 메시지", example = "")
+    String statusMessage,
+    @Schema(description = "권한", example = "USER")
+    String role,
+    @Schema(description = "생성 일시", example = "2026-03-12T10:00:00")
+    LocalDateTime createdAt,
+    @Schema(description = "수정 일시", example = "2026-03-12T10:00:00")
+    LocalDateTime updatedAt,
+    @Schema(description = "삭제 일시", example = "null", nullable = true)
+    LocalDateTime deletedAt
+) {
+    public static UserSignupResponse of(UserQueryResult result) {
+        return new UserSignupResponse(
+            result.id(),
+            result.email(),
+            result.name(),
+            result.profileImageUrl(),
+            result.statusMessage(),
+            result.role(),
+            result.createdAt(),
+            result.updatedAt(),
+            result.deletedAt()
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/global/auth/AuthenticatedUserProvider.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/global/auth/AuthenticatedUserProvider.java
@@ -1,0 +1,26 @@
+package com.lrchan.qootalk.presentation.global.auth;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.lrchan.qootalk.common.error.GlobalErrorCode;
+import com.lrchan.qootalk.common.exception.ApplicationException;
+
+@Component
+public class AuthenticatedUserProvider {
+
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getName() == null || authentication.getName().isBlank()) {
+            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        try {
+            return Long.valueOf(authentication.getName());
+        } catch (NumberFormatException e) {
+            throw new ApplicationException(GlobalErrorCode.UNAUTHORIZED, e);
+        }
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/global/config/SwaggerConfig.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/global/config/SwaggerConfig.java
@@ -34,7 +34,7 @@ public class SwaggerConfig {
     public GroupedOpenApi qooTalkApi() {
         return GroupedOpenApi.builder()
             .group("qootalk-v1")
-            .pathsToMatch("/api/v1/**")
+            .pathsToMatch("/**")
             .build();
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/global/config/SwaggerConfig.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/global/config/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.lrchan.qootalk.presentation.global.config;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("QooTalk API")
+                .description("QooTalk server API documentation")
+                .version("v1"))
+            .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+            .components(new Components()
+                .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")));
+    }
+
+    @Bean
+    public GroupedOpenApi qooTalkApi() {
+        return GroupedOpenApi.builder()
+            .group("qootalk-v1")
+            .pathsToMatch("/api/v1/**")
+            .build();
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/global/handler/GlobalExceptionHandler.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.lrchan.qootalk.presentation.global.handler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.lrchan.qootalk.common.error.ErrorCode;
+import com.lrchan.qootalk.common.error.GlobalErrorCode;
+import com.lrchan.qootalk.common.exception.ApplicationException;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.common.exception.InfrastructureException;
+import com.lrchan.qootalk.common.response.ApiResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDomainException(DomainException e) {
+        return errorResponse(e.getErrorCode());
+    }
+
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleApplicationException(ApplicationException e) {
+        return errorResponse(e.getErrorCode());
+    }
+
+    @ExceptionHandler(InfrastructureException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInfrastructureException(InfrastructureException e) {
+        return errorResponse(e.getErrorCode());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        return errorResponse(GlobalErrorCode.INTERNAL_ERROR);
+    }
+
+    private ResponseEntity<ApiResponse<Void>> errorResponse(ErrorCode errorCode) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ApiResponse.of(errorCode));
+    }
+}

--- a/qootalk-server/module-presentation/src/main/resources/application.yml
+++ b/qootalk-server/module-presentation/src/main/resources/application.yml
@@ -4,4 +4,10 @@ spring:
   # 운영환경 빌드 시 프로필 주입
   profiles:
     active: local
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
     

--- a/qootalk-server/module-presentation/src/main/resources/application.yml
+++ b/qootalk-server/module-presentation/src/main/resources/application.yml
@@ -1,3 +1,8 @@
+server:
+  servlet:
+    context-path: /api/v1
+  port: 8080
+
 spring:
   application:
     name: qootalk


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #82 
## 📝작업 내용
- **파일 관련 API 추가**
  - 파일 업로드, 목록 조회, 삭제 API를 추가하여 사용자들이 파일을 관리할 수 있도록 기능을 확장했습니다.
  
- **채팅방 관련 API 추가**
  - 채팅방 생성, 수정, 삭제, 상세 조회 및 목록 조회 API를 구현하여 채팅방 관리 기능을 강화했습니다.
  
- **사용자 프로필 관련 API 추가**
  - 회원가입 및 로그인 API를 추가하여 사용자 인증 기능을 구현했습니다. 로그인 시 토큰을 쿠키에 담아 보안성을 향상시켰습니다.
  
- **API 응답 형식 개선**
  - `ApiResponse` 클래스를 정의하여 일관된 응답 형식을 제공하도록 개선했습니다.
  
- **Swagger 문서화**
  - Swagger 관련 의존성을 추가하고 API 명세서를 업데이트하여 API 사용법을 문서화했습니다.
  
- **기타 개선사항**
  - `application.yml` 파일에 API prefix를 추가
  - API 명세서의 request/response 필드 값을 수정