### PR TITLE
refactor: 사용자 서비스 로직 및 DB 마이그레이션 개선

### DIFF
--- a/qootalk-server/README.md
+++ b/qootalk-server/README.md
@@ -1,66 +1,195 @@
-# QooTalk
+# QooTalk Server
 
-## 서비스 소개
+## 프로젝트 설명 및 목차
 
-쿠톡은 사내 커뮤니케이션을 더 빠르고 가볍게 만들어주는 실시간 메시징 플랫폼입니다.
+QooTalk Server는 사내 커뮤니케이션을 위한 채팅 백엔드 서버입니다.  
+현재 프로젝트는 인증, 사용자 프로필, 채팅방, 파일 첨부 기능을 중심으로 구현되어 있으며, 멀티모듈 기반의 계층 분리를 통해 유지보수성과 확장성을 높이는 데 초점을 맞췄습니다.
 
-QooTalk is a real-time messaging platform that makes internal communication faster, lighter, and more connected.
+- JWT 기반 로그인 및 인증 처리
+- 사용자 회원가입, 상태 메시지 수정, 프로필 이미지 업로드/삭제
+- 채팅방 생성, 목록 조회, 상세 조회, 수정, 삭제
+- 채팅 파일 업로드, 목록 조회, 삭제
+- Swagger/OpenAPI 및 마크다운 API 명세 관리
+- Flyway 기반 DB 마이그레이션 관리
+- Redis refresh token 저장소 연동
+- S3 연동 및 LocalStack 기반 로컬/테스트 환경 구성
 
-본 서비스는 텍스트 채팅, 그룹 채팅, 파일 공유, 알림 기능을 포함하여 업무 현장에서 필요한 소통 기능을 제공하며, **보안성**과 **확장성**을 최우선으로 고려하였습니다.
+### 목차
 
-### 주요 특징
-
-1. **실시간 메시징**
-   - WebSocket 기반 양방향 통신을 통한 지연 없는 대화
-   - 개인/그룹 채팅 지원  
-
-2. **협업 기능 강화**
-   - 파일 및 이미지 공유
-   - 메시지 검색 및 핀 고정 기능
-   - 프로젝트/팀 단위 채팅방 운영  
-
-3. **보안성 확보**
-   - 사용자 인증 및 권한 관리
-   - 메시지 암호화 및 로그 관리
-   - 외부 유출 방지 기능  
-
-4. **운영 효율성**
-   - Redis를 통한 세션/캐시 관리로 성능 최적화
-   - Kafka 기반 메시지 큐로 안정적인 이벤트 처리
-   - Swagger(OpenAPI)로 API 문서화 및 개발자 친화적 환경 제공  
-
----
-
-## 아키텍처
-
-QooTalk은 **멀티모듈 기반 Clean Architecture**를 적용하여 모듈 간 역할을 명확히 분리하고, 유지보수성과 확장성을 강화했습니다.
-
-
-### 📦 모듈 구성
-
-- **module-domain**  
-  비즈니스 핵심 규칙과 모델 정의
-
-- **module-application**  
-  유즈케이스(Use Case) 단위의 비즈니스 흐름 제어 계층  
-
-- **module-infrastructure**  
-  외부 시스템 연동 및 기술 구현 계층  
-
-- **module-presentation**  
-  REST API 제공 및 사용자 진입 계층
-  
-- **module-common**
-   전 계층에서 공통으로 사용하는 유틸리티 및 기본 구성 계층
----
+- [기술 스택](#기술-스택)
+- [아키텍처 및 설계](#아키텍처-및-설계)
+- [핵심 경험 및 트러블 슈팅](#핵심-경험-및-트러블-슈팅)
+- [시작 가이드](#시작-가이드)
 
 ## 기술 스택
 
-- **Backend Framework**: Spring Boot
-- **Database**: PostgreSQL  
-- **Caching & Session**: Redis  
-- **Messaging**: Apache Kafka  
-- **API 문서화**: Swagger
-- **Containerization**: Docker & Docker Compose  
+| 구분 | 사용 기술 |
+| --- | --- |
+| Language | Java 21 |
+| Framework | Spring Boot 3.5.7 |
+| Persistence | Spring Data JPA, Querydsl |
+| Database | PostgreSQL |
+| Cache | Redis |
+| Auth | Spring Security, JWT |
+| Storage | AWS S3, LocalStack |
+| Migration | Flyway |
+| API Docs | springdoc-openapi, Swagger UI, Markdown API Spec |
+| Test | JUnit 5, AssertJ, Spring Boot Test, Testcontainers |
 
----
+## 아키텍처 및 설계
+
+이 프로젝트는 `domain -> application -> infrastructure/presentation` 방향의 의존성을 유지하는 멀티모듈 구조를 사용합니다.  
+핵심 비즈니스 규칙은 도메인에 두고, 유스케이스 조합은 애플리케이션 계층에서 처리하며, 외부 기술 의존성은 인프라 계층으로 분리했습니다.
+
+### 모듈 구조
+
+| 모듈 | 역할 |
+| --- | --- |
+| `module-domain` | 엔티티, VO, 도메인 규칙, Repository 인터페이스 |
+| `module-application` | Usecase, Command/Result DTO, Port in/out, 서비스 로직 |
+| `module-infrastructure` | JPA/Redis/S3/JWT/Querydsl/Flyway 등 기술 구현체 |
+| `module-presentation` | Spring Boot 진입점, REST Controller, Swagger, Security 설정 |
+| `module-common` | 공통 응답 포맷, 공통 예외, 에러 코드, 공용 Port |
+
+### 설계 포인트
+
+1. **포트-어댑터 기반 유스케이스 분리**
+   `module-application`에서 `port.in`, `port.out`으로 인터페이스를 정의하고, 구현은 `module-infrastructure`가 담당합니다.  
+   덕분에 비즈니스 흐름이 외부 기술 세부사항에 직접 묶이지 않도록 구성했습니다.
+
+2. **공통 응답/예외 규격 통일**
+   [`docs/api-spec/README.md`](./docs/api-spec/README.md)에 정리된 형식처럼 `ApiResponse`, `PagedResponse`, `GlobalExceptionHandler`를 통해 성공/실패 응답 형식을 통일했습니다.
+
+3. **보안 책임 분리**
+   JWT 생성과 검증은 인프라 계층에서 처리하고, 프레젠테이션 계층은 인증 사용자 식별과 보안 필터 체인 구성에 집중하도록 나눴습니다.
+
+4. **운영 변경 추적**
+   DB 스키마는 Flyway 마이그레이션으로 버전 관리하고, 주요 도메인 변경 이력을 점진적으로 누적할 수 있도록 감사 로그 도메인도 분리했습니다.
+
+### 요청 흐름
+
+```text
+Client
+  -> Presentation(Controller, Security, DTO)
+  -> Application(Usecase, Service, Port)
+  -> Domain(Entity, VO, Rule, Repository Interface)
+  -> Infrastructure(JPA, Redis, S3, JWT, Querydsl)
+  -> PostgreSQL / Redis / S3
+```
+
+## 핵심 경험 및 트러블 슈팅
+
+### 1. 멀티모듈 구조에서 역할이 섞이지 않도록 설계
+
+기능이 늘어날수록 Controller, Service, Repository가 한 모듈에 몰리면 변경 영향 범위가 커지기 쉽습니다.  
+이를 줄이기 위해 도메인 모델과 유스케이스, 외부 기술 구현을 모듈 단위로 분리했고, `port.out` 인터페이스를 기준으로 의존 방향을 고정했습니다.
+
+**얻은 점**
+
+- 비즈니스 규칙과 기술 구현을 분리해 테스트 대상을 더 명확하게 나눌 수 있었음
+- Redis/S3/JPA 같은 구현을 바꿔도 유스케이스 코드 수정 범위를 줄일 수 있었음
+- API 계층이 도메인 내부 구조를 직접 침범하지 않도록 방지할 수 있었음
+
+### 2. 인증 상태를 JWT만으로 끝내지 않고 Redis와 함께 관리
+
+Access Token과 Refresh Token을 함께 사용하면서, Refresh Token 저장소를 Redis로 분리했습니다.  
+이 방식은 단순 JWT 발급보다 로그아웃, 재발급, 토큰 무효화 시나리오를 더 유연하게 처리할 수 있게 해줍니다.
+
+**적용 내용**
+
+- JWT 생성/검증 Provider 분리
+- 인증 필터와 예외 필터 분리
+- Refresh Token Redis Adapter 구성
+- 로그인 시 쿠키 기반 토큰 전달 처리
+
+### 3. S3 의존 기능을 로컬과 테스트에서 재현 가능하게 구성
+
+파일 업로드 기능은 외부 스토리지 의존성이 강해서 개발 환경마다 재현 차이가 생기기 쉽습니다.  
+이를 줄이기 위해 로컬에서는 LocalStack, 테스트에서는 Testcontainers LocalStack을 사용하도록 구성했습니다.
+
+**적용 내용**
+
+- `docker-compose.yml`로 LocalStack S3 실행
+- S3 전용 설정 클래스 및 저장소 어댑터 분리
+- 통합 테스트에서 S3 버킷 정리 루틴 포함
+
+### 4. 스키마 변경 누락을 막기 위한 Flyway 검증
+
+채팅방, 메시지, 첨부파일처럼 연관 테이블이 많은 구조에서는 DB 변경 누락이 쉽게 발생할 수 있습니다.  
+이를 대비해 Flyway migration 스크립트를 버전별로 관리하고, 검증 테스트로 현재 마이그레이션 상태를 확인할 수 있게 했습니다.
+
+**적용 내용**
+
+- `V1_1__users.sql`부터 시작하는 버전 관리형 스키마 운영
+- Flyway validate 기반 검증 테스트 작성
+- 로컬/테스트 환경 모두 동일한 migration 흐름 유지
+
+### 5. 조회성 API는 Querydsl 기반으로 확장 가능하게 설계
+
+채팅방 목록, 파일 목록처럼 조건 조합과 페이징이 필요한 API는 단순 JPA 메서드만으로 유지하기 어려워집니다.  
+이를 위해 Querydsl 설정과 Query Repository를 분리해 향후 필터 조건이 늘어나도 대응할 수 있게 구성했습니다.
+
+## 시작 가이드
+
+### 1. 사전 준비
+
+- Java 21
+- Docker / Docker Compose
+- PostgreSQL
+- Redis
+
+현재 [`docker-compose.yml`](./docker-compose.yml)은 LocalStack(S3 에뮬레이터) 중심으로 구성되어 있습니다.  
+따라서 로컬 실행 시 PostgreSQL과 Redis는 별도로 실행해야 합니다.
+
+### 2. 환경 변수 설정
+
+루트의 `.env` 파일을 사용하며, 로컬 실행 시 아래 항목이 필요합니다.
+
+- `LOCAL_DB_URL`
+- `LOCAL_DB_USERNAME`
+- `LOCAL_DB_PASSWORD`
+- `LOCAL_JPA_DDL_AUTO`
+- `LOCAL_JPA_SHOW_SQL`
+- `LOCAL_REDIS_HOST`
+- `LOCAL_REDIS_PORT`
+- `LOCAL_S3_ENDPOINT`
+- `LOCAL_S3_REGION`
+- `LOCAL_S3_ACCESS_KEY`
+- `LOCAL_S3_SECRET_KEY`
+- `LOCAL_S3_BUCKET_NAME`
+- `JWT_SECRET`
+- `JWT_ACCESS_EXPIRATION`
+- `JWT_REFRESH_EXPIRATION`
+
+운영 프로필까지 함께 관리하려면 `PROD_DB_*`, `PROD_S3_*` 값도 추가로 맞춰주면 됩니다.
+
+### 3. LocalStack 실행
+
+```bash
+docker compose up -d
+```
+
+S3 초기화 스크립트는 [`scripts/localstack/init-s3.sh`](./scripts/localstack/init-s3.sh)를 사용합니다.
+
+### 4. 애플리케이션 실행
+
+```bash
+./gradlew :module-presentation:bootRun
+```
+
+기본 실행 정보
+
+- Server Port: `8080`
+- Context Path: `/api/v1`
+- Active Profile: `local`
+
+### 5. API 문서 확인
+
+- Swagger UI: `http://localhost:8080/api/v1/swagger-ui.html`
+- OpenAPI Docs: `http://localhost:8080/api/v1/v3/api-docs`
+- Markdown API Spec: [`docs/api-spec/README.md`](./docs/api-spec/README.md)
+
+### 6. 참고 문서
+
+- API 통합 명세: [`docs/API_SPEC_V1.md`](./docs/API_SPEC_V1.md)
+- 세부 API 목록: [`docs/api-spec/README.md`](./docs/api-spec/README.md)

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/error/UserApplicationErrorCode.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/error/UserApplicationErrorCode.java
@@ -4,7 +4,8 @@ import com.lrchan.qootalk.common.error.ErrorCode;
 
 public enum UserApplicationErrorCode implements ErrorCode {
     LOGIN_FAILED("USER_001", "로그인에 실패했습니다.", 401),
-    USER_PROFILE_IMAGE_URL_MISMATCH("USER_002", "프로필 이미지 URL이 일치하지 않습니다.", 400);
+    USER_PROFILE_IMAGE_URL_MISMATCH("USER_002", "프로필 이미지 URL이 일치하지 않습니다.", 400),
+    USER_DELETED("USER_003", "삭제된 사용자입니다.", 400);
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/DeleteProfileImageService.java
@@ -29,9 +29,14 @@ public class DeleteProfileImageService implements DeleteProfileImageUsecase {
 
     @Override
     public UserQueryResult delete(DeleteProfileImageCommand command) {
+        // 유저 조회
         User user = loadUserPort.findById(command.userId())
             .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
-        
+        if (user.isDeleted()) {
+            throw new ApplicationException(UserApplicationErrorCode.USER_DELETED);
+        }
+
+        // 프로필 이미지 삭제
         if (user.profileImageUrl().value() == null) {
             return UserQueryResult.of(user);
         }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/LoginUserService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/LoginUserService.java
@@ -31,13 +31,19 @@ public class LoginUserService implements LoginUserUseCase {
 
     @Override
     public LoginResult login(LoginUserCommand command) {
+        // 유저 조회
         User user = loadUserPort.findByEmail(command.email().value())
-            .orElse(null);
+            .orElseThrow(() -> new ApplicationException(UserApplicationErrorCode.LOGIN_FAILED));
+        if (user.isDeleted()) {
+            throw new ApplicationException(UserApplicationErrorCode.USER_DELETED);
+        }
 
+        // 비밀번호 검증
         if (user == null || !passwordEncoder.matches(command.password().encryptedPassword(), user.password().encryptedPassword())) {
             throw new ApplicationException(UserApplicationErrorCode.LOGIN_FAILED);
         }
 
+        // 토큰 생성
         Token accessToken = tokenProvider.createAccessToken(String.valueOf(user.id()), user.role().name());
         Token refreshToken = tokenProvider.createRefreshToken(String.valueOf(user.id()));
 

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/RegisterUserService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/RegisterUserService.java
@@ -27,14 +27,18 @@ public class RegisterUserService implements RegisterUserUseCase {
 
     @Override
     public UserQueryResult register(RegisterUserCommand command) {
+        // 이메일 중복 검증
         if (loadUserPort.findByEmail(command.email().value()).isPresent()) {
             throw new DomainException(UserErrorCode.USER_ALREADY_EXISTS);
         }
         
+        // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(command.password().encryptedPassword());
         
+        // 유저 생성
         User user = User.create(command.email(), new Password(encodedPassword), command.name());
-        
+
+        // 유저 저장
         User registeredUser = saveUserPort.save(user);
 
         return UserQueryResult.of(registeredUser);

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/UpdateStatusMessageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/UpdateStatusMessageService.java
@@ -5,9 +5,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.lrchan.qootalk.application.user.dto.command.UpdateStatusMessageCommand;
 import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+import com.lrchan.qootalk.application.user.error.UserApplicationErrorCode;
 import com.lrchan.qootalk.application.user.port.in.UpdateStatusMessageUsecase;
 import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
 import com.lrchan.qootalk.application.user.port.out.SaveUserPort;
+import com.lrchan.qootalk.common.exception.ApplicationException;
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.domain.user.User;
 import com.lrchan.qootalk.domain.user.error.UserErrorCode;
@@ -27,9 +29,14 @@ public class UpdateStatusMessageService implements UpdateStatusMessageUsecase {
     public UserQueryResult update(UpdateStatusMessageCommand command) {
         User user = loadUserPort.findById(command.userId())
             .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.isDeleted()) {
+            throw new ApplicationException(UserApplicationErrorCode.USER_DELETED);
+        }
 
+        // 상태 메시지 수정
         user.changeStatusMessage(new StatusMessage(command.statusMessage()));
 
+        // 유저 저장
         User updatedUser = saveUserPort.save(user);
 
         return UserQueryResult.of(updatedUser);

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/UploadProfileImageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/user/service/UploadProfileImageService.java
@@ -4,11 +4,13 @@ import org.springframework.stereotype.Service;
 
 import com.lrchan.qootalk.application.user.dto.command.UploadProfileImageCommand;
 import com.lrchan.qootalk.application.user.dto.result.UserQueryResult;
+import com.lrchan.qootalk.application.user.error.UserApplicationErrorCode;
 import com.lrchan.qootalk.application.user.port.in.UploadProfileImageUsecase;
 import com.lrchan.qootalk.application.user.port.out.DeleteFilePort;
 import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
 import com.lrchan.qootalk.application.user.port.out.SaveUserPort;
 import com.lrchan.qootalk.application.user.port.out.UploadFilePort;
+import com.lrchan.qootalk.common.exception.ApplicationException;
 import com.lrchan.qootalk.common.exception.DomainException;
 import com.lrchan.qootalk.common.storage.vo.StorageResource;
 import com.lrchan.qootalk.domain.user.User;
@@ -31,7 +33,10 @@ public class UploadProfileImageService implements UploadProfileImageUsecase {
     @Override
     public UserQueryResult upload(UploadProfileImageCommand command) {
         User user = loadUserPort.findById(command.userId())
-                        .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.isDeleted()) {
+            throw new ApplicationException(UserApplicationErrorCode.USER_DELETED);
+        }
 
         String path = "profile/" + command.userId();
         StorageResource resource = new StorageResource(

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/attachment/FileAttachmentEntity.java
@@ -12,13 +12,19 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "file_attachments")
+@Table(
+    name = "file_attachments",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_file_attachments_message_id", columnNames = "message_id")
+    }
+)
 @SQLDelete(sql = "UPDATE file_attachments SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 @SuperBuilder

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageEntity.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -47,8 +48,14 @@ public class MessageEntity extends BaseEntity {
 
     // null일때 멘션 없음을 의미(체크 유의)
     @ElementCollection
-    @CollectionTable(name = "message_mentions", joinColumns = @JoinColumn(name = "message_id"))
-    @Column(name = "user_id")
+    @CollectionTable(
+        name = "message_mentions",
+        joinColumns = @JoinColumn(name = "message_id"),
+        uniqueConstraints = {
+            @UniqueConstraint(name = "uk_message_mentions_message_user", columnNames = {"message_id", "user_id"})
+        }
+    )
+    @Column(name = "user_id", nullable = false)
     @Builder.Default
     private List<Long> mentions = new ArrayList<>();
 

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/participant/RoomParticipantEntity.java
@@ -11,13 +11,19 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "room_participants")
+@Table(
+    name = "room_participants",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_room_participants_user_room", columnNames = {"user_id", "room_id"})
+    }
+)
 @SQLDelete(sql = "UPDATE room_participants SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 @SuperBuilder

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntity.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/user/UserEntity.java
@@ -6,14 +6,24 @@ import org.hibernate.annotations.SQLRestriction;
 import com.lrchan.qootalk.domain.user.UserRole;
 import com.lrchan.qootalk.infrastructure.common.BaseEntity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "users")
+@Table(
+    name = "users",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_users_email", columnNames = "email")
+    }
+)
 @SQLDelete(sql = "UPDATE users SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 @SuperBuilder
@@ -21,7 +31,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 public class UserEntity extends BaseEntity {
 
-    @Column(name = "email", nullable = false, unique = true)
+    @Column(name = "email", nullable = false)
     private String email;
 
     @Column(name = "password", nullable = false)

--- a/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_1__users.sql
+++ b/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_1__users.sql
@@ -1,7 +1,7 @@
 -- users
 create table users (
   id bigserial primary key,
-  email varchar(255) not null unique,
+  email varchar(255) not null,
   password varchar(255) not null,
   name varchar(255) not null,
   profile_image_url varchar(255),
@@ -9,5 +9,6 @@ create table users (
   role varchar(255) not null,
   created_at timestamp not null,
   updated_at timestamp not null,
-  deleted_at timestamp
+  deleted_at timestamp,
+  constraint uk_users_email unique (email)
 );

--- a/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_2__chat_rooms.sql
+++ b/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_2__chat_rooms.sql
@@ -8,5 +8,3 @@ create table chat_rooms (
   updated_at timestamp not null,
   deleted_at timestamp
 );
-
-create index idx_chat_rooms_created_by on chat_rooms(created_by);

--- a/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_3__room_participants.sql
+++ b/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_3__room_participants.sql
@@ -8,8 +8,6 @@ create table room_participants (
   notification_enabled boolean not null default true,
   created_at timestamp not null,
   updated_at timestamp not null,
-  deleted_at timestamp
+  deleted_at timestamp,
+  constraint uk_room_participants_user_room unique (user_id, room_id)
 );
-
-create index idx_room_participants_user_id on room_participants(user_id);
-create index idx_room_participants_room_id on room_participants(room_id);

--- a/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_4__messages.sql
+++ b/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_4__messages.sql
@@ -10,6 +10,3 @@ create table messages (
   updated_at timestamp not null,
   deleted_at timestamp
 );
-
-create index idx_messages_room_id on messages(room_id);
-create index idx_messages_user_id on messages(user_id);

--- a/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_5__message_mentions.sql
+++ b/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_5__message_mentions.sql
@@ -1,7 +1,6 @@
 -- message_mentions (MessageEntity.mentions @ElementCollection)
 create table message_mentions (
   message_id bigint not null,
-  user_id bigint
+  user_id bigint not null,
+  constraint uk_message_mentions_message_user unique (message_id, user_id)
 );
-
-create index idx_message_mentions_message_id on message_mentions(message_id);

--- a/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_6__file_attachments.sql
+++ b/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_6__file_attachments.sql
@@ -22,6 +22,5 @@ create table file_attachments (
 
   created_at timestamp not null,
   updated_at timestamp not null,
-  deleted_at timestamp,
-  constraint uk_file_attachments_message_id unique (message_id)
+  deleted_at timestamp
 );

--- a/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_6__file_attachments.sql
+++ b/qootalk-server/module-infrastructure/src/main/resources/db/migration/V1_6__file_attachments.sql
@@ -22,8 +22,6 @@ create table file_attachments (
 
   created_at timestamp not null,
   updated_at timestamp not null,
-  deleted_at timestamp
+  deleted_at timestamp,
+  constraint uk_file_attachments_message_id unique (message_id)
 );
-
-create index idx_file_attachments_message_id on file_attachments(message_id);
-create index idx_file_attachments_room_id on file_attachments(room_id);

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/migration/PostgresDBMigrationVerificationTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/migration/PostgresDBMigrationVerificationTest.java
@@ -52,14 +52,13 @@ class PostgresDBMigrationVerificationTest extends IntegrationTestSupport {
               AND constraint_name IN (
                 'uk_users_email',
                 'uk_room_participants_user_room',
-                'uk_file_attachments_message_id',
                 'uk_message_mentions_message_user'
               )
             """,
             Integer.class
         );
 
-        assertThat(uniqueConstraintCount).isEqualTo(4);
+        assertThat(uniqueConstraintCount).isEqualTo(3);
     }
 
     @Test

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/migration/PostgresDBMigrationVerificationTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/migration/PostgresDBMigrationVerificationTest.java
@@ -42,14 +42,48 @@ class PostgresDBMigrationVerificationTest extends IntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("messages 테이블에 room_id 인덱스가 존재해야 한다")
-    void verifyMessageRoomIdIndex() {
-        Integer indexCount = jdbcTemplate.queryForObject(
-            "SELECT count(*) FROM pg_indexes WHERE tablename = 'messages' AND indexname = 'idx_messages_room_id'",
+    @DisplayName("유니크 제약은 명시적인 UK 이름으로 생성되어야 한다")
+    void verifyNamedUniqueConstraints() {
+        Integer uniqueConstraintCount = jdbcTemplate.queryForObject(
+            """
+            SELECT count(*)
+            FROM information_schema.table_constraints
+            WHERE constraint_type = 'UNIQUE'
+              AND constraint_name IN (
+                'uk_users_email',
+                'uk_room_participants_user_room',
+                'uk_file_attachments_message_id',
+                'uk_message_mentions_message_user'
+              )
+            """,
             Integer.class
         );
 
-        assertThat(indexCount).isGreaterThan(0);
+        assertThat(uniqueConstraintCount).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("사용자 정의 일반 인덱스 없이 스키마가 생성되어야 한다")
+    void verifyNoCustomIndexesRemain() {
+        Integer indexCount = jdbcTemplate.queryForObject(
+            """
+            SELECT count(*)
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname IN (
+                'idx_chat_rooms_created_by',
+                'idx_room_participants_user_id',
+                'idx_room_participants_room_id',
+                'idx_messages_room_id',
+                'idx_messages_user_id',
+                'idx_file_attachments_room_id',
+                'idx_message_mentions_message_id'
+              )
+            """,
+            Integer.class
+        );
+
+        assertThat(indexCount).isZero();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #86 
## 📝작업 내용
- **README.md 수정**: 서비스의 주요 기능 및 기술 스택을 명확히 정리하였습니다.
  
- **유니크 제약 조건 추가**: 
  - `FileAttachmentEntity`, `MessageEntity`, `RoomParticipantEntity`, `UserEntity`에 기존 인덱스를 제거하고 유니크 제약 조건을 추가
  - 메시지 멘션 테이블에도 유니크 제약 조건을 설정하여 중복 데이터를 방지합니다.
- **데이터베이스 마이그레이션 파일 업데이트**: 
  - `V1_1__users.sql`부터 `V1_6__file_attachments.sql`까지의 마이그레이션 파일을 수정하여 새로운 유니크 제약 조건을 반영했습니다.
  - 마이그레이션 검증 테스트를 추가하여 데이터베이스 상태를 확인할 수 있도록 하였습니다.
- **유저 상태 확인 로직 추가**: 
  - `DeleteProfileImageService`, `LoginUserService`, `RegisterUserService`, `UpdateStatusMessageService`, `UploadProfileImageService`와 같은 사용자 관련 서비스에 유저 상태 확인 로직을 추가하여 서비스의 안정성을 높였습니다. 이를 통해 비정상적인 상태에서도 서비스가 올바르게 동작할 수 있도록 개선하였습니다.
