### PR TITLE
feat: 카프카 및 레디스 기반 메시징 기능 추가

### DIFF
--- a/qootalk-server/docker-compose.yml
+++ b/qootalk-server/docker-compose.yml
@@ -1,4 +1,29 @@
 services:
+  redis:
+    image: redis:7-alpine
+    container_name: qootalk_redis
+    ports:
+      - "6379:6379"
+
+  kafka:
+    image: bitnami/kafka:3.9.0
+    container_name: qootalk_kafka
+    ports:
+      - "9094:9094"
+    environment:
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    volumes:
+      - kafka_data:/bitnami/kafka
+
   localstack:
     image: localstack/localstack:latest
     container_name: localstack_s3
@@ -12,3 +37,6 @@ services:
     volumes:
       - "./localstack_data:/var/lib/localstack"
       - "./scripts/localstack/init-s3.sh:/etc/localstack/init/ready.d/init-s3.sh"
+
+volumes:
+  kafka_data:

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/DeleteMessageCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/DeleteMessageCommand.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+public record DeleteMessageCommand(
+    Long requesterId,
+    Long messageId
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/LoadChatHistoriesCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/LoadChatHistoriesCommand.java
@@ -1,0 +1,10 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+public record LoadChatHistoriesCommand(
+    Long requesterId,
+    Long roomId,
+    Long fromMessageId,
+    int page,
+    int size
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/MarkMessageReadCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/MarkMessageReadCommand.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+public record MarkMessageReadCommand(
+    Long requesterId,
+    Long roomId,
+    Long lastReadMessageId
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/UpdateMessageCommand.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/command/UpdateMessageCommand.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.dto.command;
+
+public record UpdateMessageCommand(
+    Long requesterId,
+    Long messageId,
+    String content
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/event/ChatMessageEvent.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/event/ChatMessageEvent.java
@@ -1,0 +1,33 @@
+package com.lrchan.qootalk.application.chat.dto.event;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+
+public record ChatMessageEvent(
+    Long messageId,
+    Long roomId,
+    Long senderId,
+    String content,
+    MessageType messageType,
+    List<Long> mentions,
+    Long parentMessageId,
+    List<Long> attachmentIds,
+    LocalDateTime createdAt
+) {
+    public static ChatMessageEvent of(Message message, List<Long> attachmentIds) {
+        return new ChatMessageEvent(
+            message.id(),
+            message.roomId(),
+            message.userId(),
+            message.content(),
+            message.messageType(),
+            message.mentions(),
+            message.parentMessageId(),
+            attachmentIds,
+            message.createdAt()
+        );
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/event/ReadReceiptEvent.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/event/ReadReceiptEvent.java
@@ -1,0 +1,11 @@
+package com.lrchan.qootalk.application.chat.dto.event;
+
+import java.time.LocalDateTime;
+
+public record ReadReceiptEvent(
+    Long roomId,
+    Long readerId,
+    Long lastReadMessageId,
+    LocalDateTime updatedAt
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/event/UserChatMessageEvent.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/event/UserChatMessageEvent.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.dto.event;
+
+public record UserChatMessageEvent(
+    Long recipientId,
+    ChatMessageEvent message
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/event/UserReadReceiptEvent.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/event/UserReadReceiptEvent.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.dto.event;
+
+public record UserReadReceiptEvent(
+    Long recipientId,
+    ReadReceiptEvent readReceipt
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ChatHistoryQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ChatHistoryQueryResult.java
@@ -1,0 +1,29 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+
+import lombok.Builder;
+
+@Builder
+public record ChatHistoryQueryResult(
+    Long id,
+    Long roomId,
+    Long senderId,
+    String content,
+    MessageType messageType,
+    LocalDateTime createdAt
+) {
+    public static ChatHistoryQueryResult of(Message message) {
+        return ChatHistoryQueryResult.builder()
+            .id(message.id())
+            .roomId(message.roomId())
+            .senderId(message.userId())
+            .content(message.content())
+            .messageType(message.messageType())
+            .createdAt(message.createdAt())
+            .build();
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/DeleteMessageQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/DeleteMessageQueryResult.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+public record DeleteMessageQueryResult(
+    boolean deleted,
+    Long messageId
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ReadReceiptQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/ReadReceiptQueryResult.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+public record ReadReceiptQueryResult(
+    Long roomId,
+    Long lastReadMessageId,
+    boolean updated
+) {
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/SendMessageQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/SendMessageQueryResult.java
@@ -3,8 +3,12 @@ package com.lrchan.qootalk.application.chat.dto.result;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.lrchan.qootalk.domain.chat.message.Message;
 import com.lrchan.qootalk.domain.chat.message.MessageType;
 
+import lombok.Builder;
+
+@Builder 
 public record SendMessageQueryResult(
     Long id,
     Long roomId,
@@ -16,4 +20,17 @@ public record SendMessageQueryResult(
     List<Long> attachmentIds,
     LocalDateTime createdAt
 ) {
+    public static SendMessageQueryResult of(Message message, List<Long> attachmentIds) {
+        return SendMessageQueryResult.builder()
+            .id(message.id())
+            .roomId(message.roomId())
+            .senderId(message.userId())
+            .content(message.content())
+            .messageType(message.messageType())
+            .mentions(message.mentions())
+            .parentMessageId(message.parentMessageId())
+            .attachmentIds(attachmentIds)
+            .createdAt(message.createdAt())
+            .build();
+    }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/UpdateMessageQueryResult.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/dto/result/UpdateMessageQueryResult.java
@@ -1,0 +1,19 @@
+package com.lrchan.qootalk.application.chat.dto.result;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.domain.chat.message.Message;
+
+public record UpdateMessageQueryResult(
+    Long messageId,
+    String content,
+    LocalDateTime updatedAt
+) {
+    public static UpdateMessageQueryResult of(Message message) {
+        return new UpdateMessageQueryResult(
+            message.id(),
+            message.content(),
+            message.updatedAt()
+        );
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/DeleteMessageUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/DeleteMessageUsecase.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.command.DeleteMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteMessageQueryResult;
+
+public interface DeleteMessageUsecase {
+    DeleteMessageQueryResult delete(DeleteMessageCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatHistoriesUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/LoadChatHistoriesUsecase.java
@@ -1,0 +1,9 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.command.LoadChatHistoriesCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ChatHistoryQueryResult;
+import com.lrchan.qootalk.common.response.SliceResponse;
+
+public interface LoadChatHistoriesUsecase {
+    SliceResponse<ChatHistoryQueryResult> load(LoadChatHistoriesCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/MarkMessageReadUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/MarkMessageReadUsecase.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.command.MarkMessageReadCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ReadReceiptQueryResult;
+
+public interface MarkMessageReadUsecase {
+    ReadReceiptQueryResult mark(MarkMessageReadCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/SendMessageUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/SendMessageUsecase.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.command.SendMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.result.SendMessageQueryResult;
+
+public interface SendMessageUsecase {
+    SendMessageQueryResult send(SendMessageCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/UpdateMessageUsecase.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/in/UpdateMessageUsecase.java
@@ -1,0 +1,8 @@
+package com.lrchan.qootalk.application.chat.port.in;
+
+import com.lrchan.qootalk.application.chat.dto.command.UpdateMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.result.UpdateMessageQueryResult;
+
+public interface UpdateMessageUsecase {
+    UpdateMessageQueryResult update(UpdateMessageCommand command);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadMessagePort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/LoadMessagePort.java
@@ -2,9 +2,12 @@ package com.lrchan.qootalk.application.chat.port.out;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Slice;
+
 import com.lrchan.qootalk.domain.chat.message.Message;
 
 public interface LoadMessagePort {
     Optional<Message> findById(Long id);
     Long countByRoomIdAndIdAfter(Long roomId, Long id);
+    Slice<Message> findSliceByRoomId(Long roomId, Long fromMessageId, int page, int size);
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/PublishChatMessagePort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/PublishChatMessagePort.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import com.lrchan.qootalk.application.chat.dto.event.ChatMessageEvent;
+
+public interface PublishChatMessagePort {
+    void publish(ChatMessageEvent event);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/PublishReadReceiptPort.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/port/out/PublishReadReceiptPort.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.application.chat.port.out;
+
+import com.lrchan.qootalk.application.chat.dto.event.ReadReceiptEvent;
+
+public interface PublishReadReceiptPort {
+    void publish(ReadReceiptEvent event);
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/DeleteMessageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/DeleteMessageService.java
@@ -1,0 +1,52 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lrchan.qootalk.application.chat.dto.command.DeleteMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteMessageQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.DeleteMessageUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteMessageService implements DeleteMessageUsecase {
+
+    private final LoadUserPort loadUserPort;
+    private final LoadMessagePort loadMessagePort;
+    private final SaveMessagePort saveMessagePort;
+
+    @Override
+    public DeleteMessageQueryResult delete(DeleteMessageCommand command) {
+        User user = loadUserPort.findById(command.requesterId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.deletedAt() != null) {
+            throw new DomainException(UserErrorCode.USER_DELETED);
+        }
+
+        Message message = loadMessagePort.findById(command.messageId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_MESSAGE_NOT_FOUND));
+
+        if (!command.requesterId().equals(message.userId())) {
+            throw new DomainException(ChatErrorCode.CHAT_MESSAGE_DELETE_FORBIDDEN);
+        }
+        if (message.messageType() == MessageType.SYSTEM || message.messageType() == MessageType.NOTICE) {
+            throw new DomainException(ChatErrorCode.CHAT_MESSAGE_DELETE_NOT_ALLOWED);
+        }
+
+        message.delete();
+        Message savedMessage = saveMessagePort.save(message);
+        return new DeleteMessageQueryResult(savedMessage.isDeleted(), savedMessage.id());
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatHistoriesService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/LoadChatHistoriesService.java
@@ -1,0 +1,64 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lrchan.qootalk.application.chat.dto.command.LoadChatHistoriesCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ChatHistoryQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.LoadChatHistoriesUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.common.response.SliceResponse;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoadChatHistoriesService implements LoadChatHistoriesUsecase {
+
+    private final LoadUserPort loadUserPort;
+    private final LoadChatRoomPort loadChatRoomPort;
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+    private final LoadMessagePort loadMessagePort;
+
+    @Override
+    public SliceResponse<ChatHistoryQueryResult> load(LoadChatHistoriesCommand command) {
+        User user = loadUserPort.findById(command.requesterId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.deletedAt() != null) {
+            throw new DomainException(UserErrorCode.USER_DELETED);
+        }
+
+        ChatRoom chatRoom = loadChatRoomPort.findById(command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (chatRoom.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_DELETED);
+        }
+
+        loadRoomParticipantPort.findByUserIdAndRoomId(command.requesterId(), command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
+
+        Slice<com.lrchan.qootalk.domain.chat.message.Message> messages = loadMessagePort.findSliceByRoomId(
+            command.roomId(),
+            command.fromMessageId(),
+            command.page(),
+            command.size()
+        );
+
+        return SliceResponse.of(
+            messages.getContent().stream().map(ChatHistoryQueryResult::of).toList(),
+            messages.getNumber(),
+            messages.getSize(),
+            messages.hasNext()
+        );
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/MarkMessageReadService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/MarkMessageReadService.java
@@ -1,0 +1,69 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lrchan.qootalk.application.chat.dto.command.MarkMessageReadCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ReadReceiptQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.MarkMessageReadUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MarkMessageReadService implements MarkMessageReadUsecase {
+
+    private final LoadUserPort loadUserPort;
+    private final LoadChatRoomPort loadChatRoomPort;
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+    private final LoadMessagePort loadMessagePort;
+    private final SaveRoomParticipantPort saveRoomParticipantPort;
+
+    @Override
+    public ReadReceiptQueryResult mark(MarkMessageReadCommand command) {
+        User user = loadUserPort.findById(command.requesterId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.deletedAt() != null) {
+            throw new DomainException(UserErrorCode.USER_DELETED);
+        }
+
+        ChatRoom chatRoom = loadChatRoomPort.findById(command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (chatRoom.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_DELETED);
+        }
+
+        RoomParticipant participant = loadRoomParticipantPort.findByUserIdAndRoomId(command.requesterId(), command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
+        if (participant.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_DELETED);
+        }
+
+        Message message = loadMessagePort.findById(command.lastReadMessageId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_MESSAGE_NOT_FOUND));
+        if (!command.roomId().equals(message.roomId())) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID);
+        }
+
+        if (command.lastReadMessageId() <= participant.lastReadMessageId()) {
+            return new ReadReceiptQueryResult(command.roomId(), participant.lastReadMessageId(), false);
+        }
+
+        participant.updateReadReceipt(command.lastReadMessageId());
+        saveRoomParticipantPort.save(participant);
+        return new ReadReceiptQueryResult(command.roomId(), participant.lastReadMessageId(), true);
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/MarkMessageReadService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/MarkMessageReadService.java
@@ -4,11 +4,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.lrchan.qootalk.application.chat.dto.command.MarkMessageReadCommand;
+import com.lrchan.qootalk.application.chat.dto.event.ReadReceiptEvent;
 import com.lrchan.qootalk.application.chat.dto.result.ReadReceiptQueryResult;
 import com.lrchan.qootalk.application.chat.port.in.MarkMessageReadUsecase;
 import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.PublishReadReceiptPort;
 import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
 import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
 import com.lrchan.qootalk.common.exception.DomainException;
@@ -31,6 +33,7 @@ public class MarkMessageReadService implements MarkMessageReadUsecase {
     private final LoadRoomParticipantPort loadRoomParticipantPort;
     private final LoadMessagePort loadMessagePort;
     private final SaveRoomParticipantPort saveRoomParticipantPort;
+    private final PublishReadReceiptPort publishReadReceiptPort;
 
     @Override
     public ReadReceiptQueryResult mark(MarkMessageReadCommand command) {
@@ -64,6 +67,12 @@ public class MarkMessageReadService implements MarkMessageReadUsecase {
 
         participant.updateReadReceipt(command.lastReadMessageId());
         saveRoomParticipantPort.save(participant);
+        publishReadReceiptPort.publish(new ReadReceiptEvent(
+            command.roomId(),
+            command.requesterId(),
+            participant.lastReadMessageId(),
+            participant.updatedAt()
+        ));
         return new ReadReceiptQueryResult(command.roomId(), participant.lastReadMessageId(), true);
     }
 }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/SendMessageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/SendMessageService.java
@@ -8,12 +8,14 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.lrchan.qootalk.application.chat.dto.command.SendMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.event.ChatMessageEvent;
 import com.lrchan.qootalk.application.chat.dto.result.SendMessageQueryResult;
 import com.lrchan.qootalk.application.chat.port.in.SendMessageUsecase;
 import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.PublishChatMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.SaveFileAttachmentPort;
 import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
@@ -43,6 +45,7 @@ public class SendMessageService implements SendMessageUsecase {
     private final SaveMessagePort saveMessagePort;
     private final SaveFileAttachmentPort saveFileAttachmentPort;
     private final SaveRoomParticipantPort saveRoomParticipantPort;
+    private final PublishChatMessagePort publishChatMessagePort;
 
     @Override
     public SendMessageQueryResult send(SendMessageCommand command) {
@@ -89,6 +92,9 @@ public class SendMessageService implements SendMessageUsecase {
         // 채팅방 참여자 업데이트
         participant.updateReadReceipt(savedMessage.id());
         saveRoomParticipantPort.save(participant);
+
+        // 실시간 브로드캐스팅용 이벤트 발행
+        publishChatMessagePort.publish(ChatMessageEvent.of(savedMessage, attachmentIds));
 
         return SendMessageQueryResult.of(savedMessage, attachmentIds);
     }

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/SendMessageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/SendMessageService.java
@@ -1,0 +1,156 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.lrchan.qootalk.application.chat.dto.command.SendMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.result.SendMessageQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.SendMessageUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveFileAttachmentPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.room.ChatRoom;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SendMessageService implements SendMessageUsecase {
+
+    private final LoadUserPort loadUserPort;
+    private final LoadChatRoomPort loadChatRoomPort;
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+    private final LoadMessagePort loadMessagePort;
+    private final LoadFileAttachmentPort loadFileAttachmentPort;
+    private final SaveMessagePort saveMessagePort;
+    private final SaveFileAttachmentPort saveFileAttachmentPort;
+    private final SaveRoomParticipantPort saveRoomParticipantPort;
+
+    @Override
+    public SendMessageQueryResult send(SendMessageCommand command) {
+        // 유저 검증
+        User user = loadUserPort.findById(command.requesterId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.deletedAt() != null) {
+            throw new DomainException(UserErrorCode.USER_DELETED);
+        }
+
+        // 채팅방 검증
+        ChatRoom chatRoom = loadChatRoomPort.findById(command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        if (chatRoom.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_DELETED);
+        }
+
+        // 채팅방 참여자 검증
+        RoomParticipant participant = loadRoomParticipantPort.findByUserIdAndRoomId(command.requesterId(), command.roomId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND));
+        if (participant.deletedAt() != null) {
+            throw new DomainException(ChatErrorCode.CHAT_ROOM_PARTICIPANT_DELETED);
+        }
+
+        // 메시지 타입 검증
+        MessageType messageType = command.messageType() == null ? MessageType.TEXT : command.messageType();
+        validateMessagePayload(command, messageType);
+        validateParentMessage(command.parentMessageId(), command.roomId());
+
+        // 메시지 생성
+        Message message = Message.createReply(
+            command.roomId(),
+            command.requesterId(),
+            normalizeContent(command.content()),
+            messageType,
+            command.mentions(),
+            command.parentMessageId()
+        );
+        Message savedMessage = saveMessagePort.save(message);
+
+        // 첨부파일 연결
+        List<Long> attachmentIds = bindAttachments(command, savedMessage.id());
+
+        // 채팅방 참여자 업데이트
+        participant.updateReadReceipt(savedMessage.id());
+        saveRoomParticipantPort.save(participant);
+
+        return SendMessageQueryResult.of(savedMessage, attachmentIds);
+    }
+
+    private void validateMessagePayload(SendMessageCommand command, MessageType messageType) {
+        boolean hasContent = StringUtils.hasText(command.content());
+        boolean hasAttachments = command.attachmentIds() != null && !command.attachmentIds().isEmpty();
+
+        if (!hasContent && !hasAttachments) {
+            throw new DomainException(ChatErrorCode.CHAT_MESSAGE_EMPTY_PAYLOAD);
+        }
+
+        if (messageType == MessageType.TEXT && !hasContent) {
+            throw new DomainException(ChatErrorCode.CHAT_MESSAGE_INVALID_CONTENT);
+        }
+
+        if ((messageType == MessageType.FILE || messageType == MessageType.IMAGE) && !hasAttachments) {
+            throw new DomainException(ChatErrorCode.CHAT_MESSAGE_ATTACHMENT_REQUIRED);
+        }
+    }
+
+    private void validateParentMessage(Long parentMessageId, Long roomId) {
+        if (parentMessageId == null) {
+            return;
+        }
+
+        Message parentMessage = loadMessagePort.findById(parentMessageId)
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_MESSAGE_NOT_FOUND));
+
+        if (!roomId.equals(parentMessage.roomId())) {
+            throw new DomainException(ChatErrorCode.CHAT_MESSAGE_INVALID_PARENT);
+        }
+    }
+
+    private List<Long> bindAttachments(SendMessageCommand command, Long messageId) {
+        if (command.attachmentIds() == null || command.attachmentIds().isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> attachmentIds = new ArrayList<>();
+        for (Long attachmentId : command.attachmentIds()) {
+            FileAttachment attachment = loadFileAttachmentPort.findById(attachmentId)
+                .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_FILE_ATTACHMENT_NOT_FOUND));
+
+            if (attachment.deletedAt() != null) {
+                throw new DomainException(ChatErrorCode.CHAT_FILE_ATTACHMENT_DELETED);
+            }
+            if (!command.roomId().equals(attachment.roomId())) {
+                throw new DomainException(ChatErrorCode.CHAT_MESSAGE_ATTACHMENT_ROOM_MISMATCH);
+            }
+            if (!command.requesterId().equals(attachment.uploaderId())) {
+                throw new DomainException(ChatErrorCode.CHAT_MESSAGE_ATTACHMENT_OWNER_MISMATCH);
+            }
+
+            attachment.setMessageId(messageId);
+            saveFileAttachmentPort.save(attachment);
+            attachmentIds.add(attachment.id());
+        }
+        return List.copyOf(attachmentIds);
+    }
+
+    private String normalizeContent(String content) {
+        return StringUtils.hasText(content) ? content.trim() : null;
+    }
+}

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/SendMessageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/SendMessageService.java
@@ -1,7 +1,9 @@
 package com.lrchan.qootalk.application.chat.service;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -74,6 +76,7 @@ public class SendMessageService implements SendMessageUsecase {
         MessageType messageType = command.messageType() == null ? MessageType.TEXT : command.messageType();
         validateMessagePayload(command, messageType);
         validateParentMessage(command.parentMessageId(), command.roomId());
+        validateMentions(command.mentions(), command.roomId());
 
         // 메시지 생성
         Message message = Message.createReply(
@@ -103,6 +106,10 @@ public class SendMessageService implements SendMessageUsecase {
         boolean hasContent = StringUtils.hasText(command.content());
         boolean hasAttachments = command.attachmentIds() != null && !command.attachmentIds().isEmpty();
 
+        if (messageType == MessageType.SYSTEM || messageType == MessageType.NOTICE) {
+            throw new DomainException(ChatErrorCode.CHAT_MESSAGE_TYPE_NOT_ALLOWED);
+        }
+
         if (!hasContent && !hasAttachments) {
             throw new DomainException(ChatErrorCode.CHAT_MESSAGE_EMPTY_PAYLOAD);
         }
@@ -113,6 +120,13 @@ public class SendMessageService implements SendMessageUsecase {
 
         if ((messageType == MessageType.FILE || messageType == MessageType.IMAGE) && !hasAttachments) {
             throw new DomainException(ChatErrorCode.CHAT_MESSAGE_ATTACHMENT_REQUIRED);
+        }
+
+        if (hasAttachments) {
+            Set<Long> uniqueAttachmentIds = new LinkedHashSet<>(command.attachmentIds());
+            if (uniqueAttachmentIds.size() != command.attachmentIds().size()) {
+                throw new DomainException(ChatErrorCode.CHAT_MESSAGE_DUPLICATE_ATTACHMENT);
+            }
         }
     }
 
@@ -154,6 +168,22 @@ public class SendMessageService implements SendMessageUsecase {
             attachmentIds.add(attachment.id());
         }
         return List.copyOf(attachmentIds);
+    }
+
+    private void validateMentions(List<Long> mentions, Long roomId) {
+        if (mentions == null || mentions.isEmpty()) {
+            return;
+        }
+
+        Set<Long> participantIds = loadRoomParticipantPort.findActiveByRoomId(roomId).stream()
+            .map(RoomParticipant::userId)
+            .collect(java.util.stream.Collectors.toSet());
+
+        for (Long mentionedUserId : mentions) {
+            if (!participantIds.contains(mentionedUserId)) {
+                throw new DomainException(ChatErrorCode.CHAT_MESSAGE_MENTION_TARGET_NOT_FOUND);
+            }
+        }
     }
 
     private String normalizeContent(String content) {

--- a/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/UpdateMessageService.java
+++ b/qootalk-server/module-application/src/main/java/com/lrchan/qootalk/application/chat/service/UpdateMessageService.java
@@ -1,0 +1,56 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.lrchan.qootalk.application.chat.dto.command.UpdateMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.result.UpdateMessageQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.UpdateMessageUsecase;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.user.User;
+import com.lrchan.qootalk.domain.user.error.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateMessageService implements UpdateMessageUsecase {
+
+    private final LoadUserPort loadUserPort;
+    private final LoadMessagePort loadMessagePort;
+    private final SaveMessagePort saveMessagePort;
+
+    @Override
+    public UpdateMessageQueryResult update(UpdateMessageCommand command) {
+        User user = loadUserPort.findById(command.requesterId())
+            .orElseThrow(() -> new DomainException(UserErrorCode.USER_NOT_FOUND));
+        if (user.deletedAt() != null) {
+            throw new DomainException(UserErrorCode.USER_DELETED);
+        }
+
+        Message message = loadMessagePort.findById(command.messageId())
+            .orElseThrow(() -> new DomainException(ChatErrorCode.CHAT_MESSAGE_NOT_FOUND));
+
+        if (!command.requesterId().equals(message.userId())) {
+            throw new DomainException(ChatErrorCode.CHAT_MESSAGE_EDIT_FORBIDDEN);
+        }
+        if (message.messageType() == MessageType.SYSTEM || message.messageType() == MessageType.NOTICE) {
+            throw new DomainException(ChatErrorCode.CHAT_MESSAGE_UPDATE_NOT_ALLOWED);
+        }
+        if (!StringUtils.hasText(command.content())) {
+            throw new DomainException(ChatErrorCode.CHAT_MESSAGE_INVALID_CONTENT);
+        }
+
+        message.changeContent(command.content().trim());
+        Message savedMessage = saveMessagePort.save(message);
+        return UpdateMessageQueryResult.of(savedMessage);
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/DeleteMessageServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/DeleteMessageServiceTest.java
@@ -1,0 +1,69 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.DeleteMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteMessageQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteMessageServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadMessagePort loadMessagePort;
+    @Mock
+    private SaveMessagePort saveMessagePort;
+
+    @InjectMocks
+    private DeleteMessageService deleteMessageService;
+
+    @Test
+    @DisplayName("작성자는 메시지를 삭제할 수 있다")
+    void delete_success() {
+        DeleteMessageCommand command = new DeleteMessageCommand(1L, 100L);
+        Message message = ChatServiceTestFixtures.message(100L, 10L, 1L, "삭제 대상", MessageType.TEXT);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadMessagePort.findById(100L)).willReturn(Optional.of(message));
+        given(saveMessagePort.save(any(Message.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        DeleteMessageQueryResult result = deleteMessageService.delete(command);
+
+        assertThat(result.deleted()).isTrue();
+        assertThat(result.messageId()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("작성자가 아닌 사용자는 메시지를 삭제할 수 없다")
+    void delete_fail_whenRequesterIsNotAuthor() {
+        DeleteMessageCommand command = new DeleteMessageCommand(2L, 100L);
+        Message message = ChatServiceTestFixtures.message(100L, 10L, 1L, "삭제 대상", MessageType.TEXT);
+
+        given(loadUserPort.findById(2L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(2L)));
+        given(loadMessagePort.findById(100L)).willReturn(Optional.of(message));
+
+        assertThatThrownBy(() -> deleteMessageService.delete(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_MESSAGE_DELETE_FORBIDDEN.getMessage());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/LoadChatHistoriesServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/LoadChatHistoriesServiceTest.java
@@ -1,0 +1,83 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+import com.lrchan.qootalk.application.chat.dto.command.LoadChatHistoriesCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ChatHistoryQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.common.response.SliceResponse;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+
+@ExtendWith(MockitoExtension.class)
+class LoadChatHistoriesServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadChatRoomPort loadChatRoomPort;
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+    @Mock
+    private LoadMessagePort loadMessagePort;
+
+    @InjectMocks
+    private LoadChatHistoriesService loadChatHistoriesService;
+
+    @Test
+    @DisplayName("채팅 이력은 Slice 형태로 조회된다")
+    void load_success() {
+        LoadChatHistoriesCommand command = new LoadChatHistoriesCommand(1L, 10L, null, 0, 2);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true)));
+        given(loadMessagePort.findSliceByRoomId(10L, null, 0, 2)).willReturn(new SliceImpl<>(
+            List.of(
+                ChatServiceTestFixtures.message(5L, 10L, 1L, "latest", MessageType.TEXT),
+                ChatServiceTestFixtures.message(4L, 10L, 2L, "previous", MessageType.TEXT)
+            ),
+            PageRequest.of(0, 2),
+            true
+        ));
+
+        SliceResponse<ChatHistoryQueryResult> result = loadChatHistoriesService.load(command);
+
+        assertThat(result.content()).hasSize(2);
+        assertThat(result.content().get(0).content()).isEqualTo("latest");
+        assertThat(result.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("참여하지 않은 사용자는 채팅 이력을 조회할 수 없다")
+    void load_fail_whenNotParticipant() {
+        LoadChatHistoriesCommand command = new LoadChatHistoriesCommand(1L, 10L, null, 0, 20);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> loadChatHistoriesService.load(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_ROOM_PARTICIPANT_NOT_FOUND.getMessage());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/MarkMessageReadServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/MarkMessageReadServiceTest.java
@@ -1,0 +1,96 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.MarkMessageReadCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ReadReceiptQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+
+@ExtendWith(MockitoExtension.class)
+class MarkMessageReadServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadChatRoomPort loadChatRoomPort;
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+    @Mock
+    private LoadMessagePort loadMessagePort;
+    @Mock
+    private SaveRoomParticipantPort saveRoomParticipantPort;
+
+    @InjectMocks
+    private MarkMessageReadService markMessageReadService;
+
+    @Test
+    @DisplayName("더 최신 메시지를 읽음 처리하면 마지막 읽음 메시지 ID가 갱신된다")
+    void mark_success() {
+        MarkMessageReadCommand command = new MarkMessageReadCommand(1L, 10L, 20L);
+        RoomParticipant participant = ChatServiceTestFixtures.participant(100L, 1L, 10L, 10L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L)).willReturn(Optional.of(participant));
+        given(loadMessagePort.findById(20L)).willReturn(Optional.of(ChatServiceTestFixtures.message(20L, 10L, 2L, "message", MessageType.TEXT)));
+
+        ReadReceiptQueryResult result = markMessageReadService.mark(command);
+
+        assertThat(result.updated()).isTrue();
+        assertThat(result.lastReadMessageId()).isEqualTo(20L);
+        verify(saveRoomParticipantPort).save(participant);
+    }
+
+    @Test
+    @DisplayName("이미 읽은 메시지 이하를 읽음 처리하면 갱신하지 않는다")
+    void mark_success_whenAlreadyRead() {
+        MarkMessageReadCommand command = new MarkMessageReadCommand(1L, 10L, 10L);
+        RoomParticipant participant = ChatServiceTestFixtures.participant(100L, 1L, 10L, 10L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L)).willReturn(Optional.of(participant));
+        given(loadMessagePort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.message(10L, 10L, 2L, "message", MessageType.TEXT)));
+
+        ReadReceiptQueryResult result = markMessageReadService.mark(command);
+
+        assertThat(result.updated()).isFalse();
+        assertThat(result.lastReadMessageId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("다른 채팅방 메시지를 읽음 처리하면 예외가 발생한다")
+    void mark_fail_whenMessageBelongsToAnotherRoom() {
+        MarkMessageReadCommand command = new MarkMessageReadCommand(1L, 10L, 20L);
+        RoomParticipant participant = ChatServiceTestFixtures.participant(100L, 1L, 10L, 10L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L)).willReturn(Optional.of(participant));
+        given(loadMessagePort.findById(20L)).willReturn(Optional.of(ChatServiceTestFixtures.message(20L, 99L, 2L, "message", MessageType.TEXT)));
+
+        assertThatThrownBy(() -> markMessageReadService.mark(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_ROOM_PARTICIPANT_INVALID_LAST_READ_MESSAGE_ID.getMessage());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/MarkMessageReadServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/MarkMessageReadServiceTest.java
@@ -3,6 +3,7 @@ package com.lrchan.qootalk.application.chat.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.Optional;
@@ -19,6 +20,7 @@ import com.lrchan.qootalk.application.chat.dto.result.ReadReceiptQueryResult;
 import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.PublishReadReceiptPort;
 import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
 import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
 import com.lrchan.qootalk.common.exception.DomainException;
@@ -39,6 +41,8 @@ class MarkMessageReadServiceTest {
     private LoadMessagePort loadMessagePort;
     @Mock
     private SaveRoomParticipantPort saveRoomParticipantPort;
+    @Mock
+    private PublishReadReceiptPort publishReadReceiptPort;
 
     @InjectMocks
     private MarkMessageReadService markMessageReadService;
@@ -59,6 +63,7 @@ class MarkMessageReadServiceTest {
         assertThat(result.updated()).isTrue();
         assertThat(result.lastReadMessageId()).isEqualTo(20L);
         verify(saveRoomParticipantPort).save(participant);
+        verify(publishReadReceiptPort).publish(org.mockito.ArgumentMatchers.any());
     }
 
     @Test
@@ -76,6 +81,8 @@ class MarkMessageReadServiceTest {
 
         assertThat(result.updated()).isFalse();
         assertThat(result.lastReadMessageId()).isEqualTo(10L);
+        verify(saveRoomParticipantPort, never()).save(participant);
+        verify(publishReadReceiptPort, never()).publish(org.mockito.ArgumentMatchers.any());
     }
 
     @Test

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/SendMessageServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/SendMessageServiceTest.java
@@ -71,6 +71,10 @@ class SendMessageServiceTest {
         given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
         given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
         given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L)).willReturn(Optional.of(participant));
+        given(loadRoomParticipantPort.findActiveByRoomId(10L)).willReturn(List.of(
+            ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true),
+            ChatServiceTestFixtures.participant(101L, 2L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true)
+        ));
         given(saveMessagePort.save(any(Message.class))).willReturn(savedMessage);
 
         SendMessageQueryResult result = sendMessageService.send(command);
@@ -126,6 +130,21 @@ class SendMessageServiceTest {
     }
 
     @Test
+    @DisplayName("사용자는 SYSTEM 메시지를 전송할 수 없다")
+    void send_fail_whenMessageTypeNotAllowed() {
+        SendMessageCommand command = new SendMessageCommand(1L, 10L, "시스템 공지", MessageType.SYSTEM, List.of(), null, List.of());
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true)));
+
+        assertThatThrownBy(() -> sendMessageService.send(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_MESSAGE_TYPE_NOT_ALLOWED.getMessage());
+    }
+
+    @Test
     @DisplayName("다른 채팅방의 부모 메시지로 답장을 보내면 예외가 발생한다")
     void send_fail_whenParentMessageBelongsToAnotherRoom() {
         SendMessageCommand command = new SendMessageCommand(1L, 10L, "답장", MessageType.REPLY, List.of(), 99L, List.of());
@@ -139,6 +158,25 @@ class SendMessageServiceTest {
         assertThatThrownBy(() -> sendMessageService.send(command))
             .isInstanceOf(DomainException.class)
             .hasMessage(ChatErrorCode.CHAT_MESSAGE_INVALID_PARENT.getMessage());
+    }
+
+    @Test
+    @DisplayName("채팅방 참여자가 아닌 사용자를 멘션하면 예외가 발생한다")
+    void send_fail_whenMentionTargetNotParticipant() {
+        SendMessageCommand command = new SendMessageCommand(1L, 10L, "멘션", MessageType.TEXT, List.of(99L), null, List.of());
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true)));
+        given(loadRoomParticipantPort.findActiveByRoomId(10L)).willReturn(List.of(
+            ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true),
+            ChatServiceTestFixtures.participant(101L, 2L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true)
+        ));
+
+        assertThatThrownBy(() -> sendMessageService.send(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_MESSAGE_MENTION_TARGET_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -157,5 +195,20 @@ class SendMessageServiceTest {
         assertThatThrownBy(() -> sendMessageService.send(command))
             .isInstanceOf(DomainException.class)
             .hasMessage(ChatErrorCode.CHAT_MESSAGE_ATTACHMENT_OWNER_MISMATCH.getMessage());
+    }
+
+    @Test
+    @DisplayName("중복된 첨부파일 ID는 메시지에 포함할 수 없다")
+    void send_fail_whenAttachmentIdsDuplicated() {
+        SendMessageCommand command = new SendMessageCommand(1L, 10L, null, MessageType.FILE, List.of(), null, List.of(31L, 31L));
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true)));
+
+        assertThatThrownBy(() -> sendMessageService.send(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_MESSAGE_DUPLICATE_ATTACHMENT.getMessage());
     }
 }

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/SendMessageServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/SendMessageServiceTest.java
@@ -1,0 +1,156 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.SendMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.result.SendMessageQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveFileAttachmentPort;
+import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.attachment.FileAttachment;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+
+@ExtendWith(MockitoExtension.class)
+class SendMessageServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadChatRoomPort loadChatRoomPort;
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+    @Mock
+    private LoadMessagePort loadMessagePort;
+    @Mock
+    private LoadFileAttachmentPort loadFileAttachmentPort;
+    @Mock
+    private SaveMessagePort saveMessagePort;
+    @Mock
+    private SaveFileAttachmentPort saveFileAttachmentPort;
+    @Mock
+    private SaveRoomParticipantPort saveRoomParticipantPort;
+
+    @InjectMocks
+    private SendMessageService sendMessageService;
+
+    @Test
+    @DisplayName("메시지 전송에 성공하면 메시지를 저장하고 발신자의 읽음 위치를 갱신한다")
+    void send_success() {
+        SendMessageCommand command = new SendMessageCommand(1L, 10L, "안녕하세요", MessageType.TEXT, List.of(2L), null, List.of());
+        RoomParticipant participant = ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true);
+        Message savedMessage = ChatServiceTestFixtures.message(20L, 10L, 1L, "안녕하세요", MessageType.TEXT);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L)).willReturn(Optional.of(participant));
+        given(saveMessagePort.save(any(Message.class))).willReturn(savedMessage);
+
+        SendMessageQueryResult result = sendMessageService.send(command);
+
+        assertThat(result.id()).isEqualTo(20L);
+        assertThat(result.roomId()).isEqualTo(10L);
+        assertThat(result.senderId()).isEqualTo(1L);
+        assertThat(result.content()).isEqualTo("안녕하세요");
+        assertThat(result.attachmentIds()).isEmpty();
+
+        ArgumentCaptor<RoomParticipant> participantCaptor = ArgumentCaptor.forClass(RoomParticipant.class);
+        verify(saveRoomParticipantPort).save(participantCaptor.capture());
+        assertThat(participantCaptor.getValue().lastReadMessageId()).isEqualTo(20L);
+    }
+
+    @Test
+    @DisplayName("첨부파일 메시지 전송에 성공하면 첨부파일을 새 메시지에 연결한다")
+    void send_success_withAttachments() {
+        SendMessageCommand command = new SendMessageCommand(1L, 10L, null, MessageType.FILE, List.of(), null, List.of(31L, 32L));
+        RoomParticipant participant = ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true);
+        Message savedMessage = ChatServiceTestFixtures.message(20L, 10L, 1L, null, MessageType.FILE);
+        FileAttachment attachment1 = ChatServiceTestFixtures.attachment(31L, 10L, 1L, 1L, "doc-1.pdf", com.lrchan.qootalk.domain.chat.attachment.FileType.DOCUMENT);
+        FileAttachment attachment2 = ChatServiceTestFixtures.attachment(32L, 10L, 1L, 1L, "doc-2.pdf", com.lrchan.qootalk.domain.chat.attachment.FileType.DOCUMENT);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L)).willReturn(Optional.of(participant));
+        given(saveMessagePort.save(any(Message.class))).willReturn(savedMessage);
+        given(loadFileAttachmentPort.findById(31L)).willReturn(Optional.of(attachment1));
+        given(loadFileAttachmentPort.findById(32L)).willReturn(Optional.of(attachment2));
+
+        SendMessageQueryResult result = sendMessageService.send(command);
+
+        assertThat(result.attachmentIds()).containsExactly(31L, 32L);
+        verify(saveFileAttachmentPort, times(2)).save(any(FileAttachment.class));
+    }
+
+    @Test
+    @DisplayName("메시지 내용과 첨부파일이 모두 없으면 예외가 발생한다")
+    void send_fail_whenPayloadEmpty() {
+        SendMessageCommand command = new SendMessageCommand(1L, 10L, "   ", MessageType.TEXT, List.of(), null, List.of());
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true)));
+
+        assertThatThrownBy(() -> sendMessageService.send(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_MESSAGE_EMPTY_PAYLOAD.getMessage());
+    }
+
+    @Test
+    @DisplayName("다른 채팅방의 부모 메시지로 답장을 보내면 예외가 발생한다")
+    void send_fail_whenParentMessageBelongsToAnotherRoom() {
+        SendMessageCommand command = new SendMessageCommand(1L, 10L, "답장", MessageType.REPLY, List.of(), 99L, List.of());
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true)));
+        given(loadMessagePort.findById(99L)).willReturn(Optional.of(ChatServiceTestFixtures.message(99L, 20L, 2L, "다른 방 메시지", MessageType.TEXT)));
+
+        assertThatThrownBy(() -> sendMessageService.send(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_MESSAGE_INVALID_PARENT.getMessage());
+    }
+
+    @Test
+    @DisplayName("본인이 업로드하지 않은 첨부파일은 메시지에 포함할 수 없다")
+    void send_fail_whenAttachmentOwnerMismatch() {
+        SendMessageCommand command = new SendMessageCommand(1L, 10L, null, MessageType.FILE, List.of(), null, List.of(31L));
+        FileAttachment attachment = ChatServiceTestFixtures.attachment(31L, 10L, 1L, 2L, "doc.pdf", com.lrchan.qootalk.domain.chat.attachment.FileType.DOCUMENT);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadChatRoomPort.findById(10L)).willReturn(Optional.of(ChatServiceTestFixtures.activeRoom(10L, 1L)));
+        given(loadRoomParticipantPort.findByUserIdAndRoomId(1L, 10L))
+            .willReturn(Optional.of(ChatServiceTestFixtures.participant(100L, 1L, 10L, 1L, com.lrchan.qootalk.domain.chat.participant.RoomRole.MEMBER, true)));
+        given(saveMessagePort.save(any(Message.class))).willReturn(ChatServiceTestFixtures.message(20L, 10L, 1L, null, MessageType.FILE));
+        given(loadFileAttachmentPort.findById(31L)).willReturn(Optional.of(attachment));
+
+        assertThatThrownBy(() -> sendMessageService.send(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_MESSAGE_ATTACHMENT_OWNER_MISMATCH.getMessage());
+    }
+}

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/SendMessageServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/SendMessageServiceTest.java
@@ -24,6 +24,7 @@ import com.lrchan.qootalk.application.chat.port.out.LoadChatRoomPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadFileAttachmentPort;
 import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.application.chat.port.out.PublishChatMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.SaveFileAttachmentPort;
 import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
 import com.lrchan.qootalk.application.chat.port.out.SaveRoomParticipantPort;
@@ -54,6 +55,8 @@ class SendMessageServiceTest {
     private SaveFileAttachmentPort saveFileAttachmentPort;
     @Mock
     private SaveRoomParticipantPort saveRoomParticipantPort;
+    @Mock
+    private PublishChatMessagePort publishChatMessagePort;
 
     @InjectMocks
     private SendMessageService sendMessageService;
@@ -81,6 +84,7 @@ class SendMessageServiceTest {
         ArgumentCaptor<RoomParticipant> participantCaptor = ArgumentCaptor.forClass(RoomParticipant.class);
         verify(saveRoomParticipantPort).save(participantCaptor.capture());
         assertThat(participantCaptor.getValue().lastReadMessageId()).isEqualTo(20L);
+        verify(publishChatMessagePort).publish(any());
     }
 
     @Test
@@ -103,6 +107,7 @@ class SendMessageServiceTest {
 
         assertThat(result.attachmentIds()).containsExactly(31L, 32L);
         verify(saveFileAttachmentPort, times(2)).save(any(FileAttachment.class));
+        verify(publishChatMessagePort).publish(any());
     }
 
     @Test

--- a/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/UpdateMessageServiceTest.java
+++ b/qootalk-server/module-application/src/test/java/com/lrchan/qootalk/application/chat/service/UpdateMessageServiceTest.java
@@ -1,0 +1,83 @@
+package com.lrchan.qootalk.application.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lrchan.qootalk.application.chat.dto.command.UpdateMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.result.UpdateMessageQueryResult;
+import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
+import com.lrchan.qootalk.application.chat.port.out.SaveMessagePort;
+import com.lrchan.qootalk.application.user.port.out.LoadUserPort;
+import com.lrchan.qootalk.common.exception.DomainException;
+import com.lrchan.qootalk.domain.chat.error.ChatErrorCode;
+import com.lrchan.qootalk.domain.chat.message.Message;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateMessageServiceTest {
+
+    @Mock
+    private LoadUserPort loadUserPort;
+    @Mock
+    private LoadMessagePort loadMessagePort;
+    @Mock
+    private SaveMessagePort saveMessagePort;
+
+    @InjectMocks
+    private UpdateMessageService updateMessageService;
+
+    @Test
+    @DisplayName("작성자는 메시지 내용을 수정할 수 있다")
+    void update_success() {
+        UpdateMessageCommand command = new UpdateMessageCommand(1L, 100L, "수정된 메시지");
+        Message message = ChatServiceTestFixtures.message(100L, 10L, 1L, "기존 메시지", MessageType.TEXT);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadMessagePort.findById(100L)).willReturn(Optional.of(message));
+        given(saveMessagePort.save(any(Message.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateMessageQueryResult result = updateMessageService.update(command);
+
+        assertThat(result.messageId()).isEqualTo(100L);
+        assertThat(result.content()).isEqualTo("수정된 메시지");
+    }
+
+    @Test
+    @DisplayName("작성자가 아닌 사용자는 메시지를 수정할 수 없다")
+    void update_fail_whenRequesterIsNotAuthor() {
+        UpdateMessageCommand command = new UpdateMessageCommand(2L, 100L, "수정 시도");
+        Message message = ChatServiceTestFixtures.message(100L, 10L, 1L, "기존 메시지", MessageType.TEXT);
+
+        given(loadUserPort.findById(2L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(2L)));
+        given(loadMessagePort.findById(100L)).willReturn(Optional.of(message));
+
+        assertThatThrownBy(() -> updateMessageService.update(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_MESSAGE_EDIT_FORBIDDEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("빈 내용으로는 메시지를 수정할 수 없다")
+    void update_fail_whenContentBlank() {
+        UpdateMessageCommand command = new UpdateMessageCommand(1L, 100L, "   ");
+        Message message = ChatServiceTestFixtures.message(100L, 10L, 1L, "기존 메시지", MessageType.TEXT);
+
+        given(loadUserPort.findById(1L)).willReturn(Optional.of(ChatServiceTestFixtures.activeUser(1L)));
+        given(loadMessagePort.findById(100L)).willReturn(Optional.of(message));
+
+        assertThatThrownBy(() -> updateMessageService.update(command))
+            .isInstanceOf(DomainException.class)
+            .hasMessage(ChatErrorCode.CHAT_MESSAGE_INVALID_CONTENT.getMessage());
+    }
+}

--- a/qootalk-server/module-common/src/main/java/com/lrchan/qootalk/common/response/SliceResponse.java
+++ b/qootalk-server/module-common/src/main/java/com/lrchan/qootalk/common/response/SliceResponse.java
@@ -1,0 +1,14 @@
+package com.lrchan.qootalk.common.response;
+
+import java.util.List;
+
+public record SliceResponse<T>(
+    List<T> content,
+    int page,
+    int size,
+    boolean hasNext
+) {
+    public static <T> SliceResponse<T> of(List<T> content, int page, int size, boolean hasNext) {
+        return new SliceResponse<>(content, page, size, hasNext);
+    }
+}

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
@@ -35,7 +35,9 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_MESSAGE_MENTION_TARGET_NOT_FOUND("CHAT_028", "멘션 대상은 현재 채팅방 참여자여야 합니다.", 400),
     CHAT_MESSAGE_DUPLICATE_ATTACHMENT("CHAT_029", "중복된 첨부파일 ID는 전송할 수 없습니다.", 400),
     CHAT_MESSAGE_EDIT_FORBIDDEN("CHAT_030", "본인이 작성한 메시지만 수정할 수 있습니다.", 403),
-    CHAT_MESSAGE_UPDATE_NOT_ALLOWED("CHAT_031", "해당 메시지 타입은 수정할 수 없습니다.", 400);
+    CHAT_MESSAGE_UPDATE_NOT_ALLOWED("CHAT_031", "해당 메시지 타입은 수정할 수 없습니다.", 400),
+    CHAT_MESSAGE_DELETE_FORBIDDEN("CHAT_032", "본인이 작성한 메시지만 삭제할 수 있습니다.", 403),
+    CHAT_MESSAGE_DELETE_NOT_ALLOWED("CHAT_033", "해당 메시지 타입은 삭제할 수 없습니다.", 400);
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
@@ -23,7 +23,14 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_FILE_METADATA_INVALID_PATH("CHAT_016", "파일 경로가 올바르지 않습니다.", 400),
     CHAT_FILE_METADATA_INVALID_INPUT_STREAM("CHAT_017", "파일 입력 스트림이 올바르지 않습니다.", 400),
     CHAT_FILE_ATTACHMENT_NOT_FOUND("CHAT_018", "파일 첨부파일을 찾을 수 없습니다.", 404),
-    CHAT_FILE_ATTACHMENT_DELETED("CHAT_019", "파일 첨부파일이 삭제되었습니다.", 404);
+    CHAT_FILE_ATTACHMENT_DELETED("CHAT_019", "파일 첨부파일이 삭제되었습니다.", 404),
+    CHAT_MESSAGE_NOT_FOUND("CHAT_020", "메시지를 찾을 수 없습니다.", 404),
+    CHAT_MESSAGE_EMPTY_PAYLOAD("CHAT_021", "메시지 내용 또는 첨부파일이 필요합니다.", 400),
+    CHAT_MESSAGE_INVALID_CONTENT("CHAT_022", "메시지 내용이 올바르지 않습니다.", 400),
+    CHAT_MESSAGE_ATTACHMENT_REQUIRED("CHAT_023", "해당 메시지 타입에는 첨부파일이 필요합니다.", 400),
+    CHAT_MESSAGE_INVALID_PARENT("CHAT_024", "부모 메시지가 현재 채팅방에 속하지 않습니다.", 400),
+    CHAT_MESSAGE_ATTACHMENT_ROOM_MISMATCH("CHAT_025", "첨부파일이 현재 채팅방에 속하지 않습니다.", 400),
+    CHAT_MESSAGE_ATTACHMENT_OWNER_MISMATCH("CHAT_026", "본인이 업로드한 첨부파일만 전송할 수 있습니다.", 400);
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
@@ -33,7 +33,9 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_MESSAGE_ATTACHMENT_OWNER_MISMATCH("CHAT_026", "본인이 업로드한 첨부파일만 전송할 수 있습니다.", 400),
     CHAT_MESSAGE_TYPE_NOT_ALLOWED("CHAT_027", "사용자가 전송할 수 없는 메시지 타입입니다.", 400),
     CHAT_MESSAGE_MENTION_TARGET_NOT_FOUND("CHAT_028", "멘션 대상은 현재 채팅방 참여자여야 합니다.", 400),
-    CHAT_MESSAGE_DUPLICATE_ATTACHMENT("CHAT_029", "중복된 첨부파일 ID는 전송할 수 없습니다.", 400);
+    CHAT_MESSAGE_DUPLICATE_ATTACHMENT("CHAT_029", "중복된 첨부파일 ID는 전송할 수 없습니다.", 400),
+    CHAT_MESSAGE_EDIT_FORBIDDEN("CHAT_030", "본인이 작성한 메시지만 수정할 수 있습니다.", 403),
+    CHAT_MESSAGE_UPDATE_NOT_ALLOWED("CHAT_031", "해당 메시지 타입은 수정할 수 없습니다.", 400);
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/error/ChatErrorCode.java
@@ -30,7 +30,10 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_MESSAGE_ATTACHMENT_REQUIRED("CHAT_023", "해당 메시지 타입에는 첨부파일이 필요합니다.", 400),
     CHAT_MESSAGE_INVALID_PARENT("CHAT_024", "부모 메시지가 현재 채팅방에 속하지 않습니다.", 400),
     CHAT_MESSAGE_ATTACHMENT_ROOM_MISMATCH("CHAT_025", "첨부파일이 현재 채팅방에 속하지 않습니다.", 400),
-    CHAT_MESSAGE_ATTACHMENT_OWNER_MISMATCH("CHAT_026", "본인이 업로드한 첨부파일만 전송할 수 있습니다.", 400);
+    CHAT_MESSAGE_ATTACHMENT_OWNER_MISMATCH("CHAT_026", "본인이 업로드한 첨부파일만 전송할 수 있습니다.", 400),
+    CHAT_MESSAGE_TYPE_NOT_ALLOWED("CHAT_027", "사용자가 전송할 수 없는 메시지 타입입니다.", 400),
+    CHAT_MESSAGE_MENTION_TARGET_NOT_FOUND("CHAT_028", "멘션 대상은 현재 채팅방 참여자여야 합니다.", 400),
+    CHAT_MESSAGE_DUPLICATE_ATTACHMENT("CHAT_029", "중복된 첨부파일 ID는 전송할 수 없습니다.", 400);
 
     private final String code;
     private final String message;

--- a/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/message/Message.java
+++ b/qootalk-server/module-domain/src/main/java/com/lrchan/qootalk/domain/chat/message/Message.java
@@ -82,4 +82,9 @@ public class Message extends BaseModel {
         this.mentions = userIds == null ? new ArrayList<>() : new ArrayList<>(userIds);
         update();
     }
+
+    public void delete() {
+        softDelete();
+        update();
+    }
 }

--- a/qootalk-server/module-infrastructure/build.gradle
+++ b/qootalk-server/module-infrastructure/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'org.postgresql:postgresql'
 
 	// Querydsl
@@ -46,12 +47,15 @@ dependencies {
 	// TestContainers
 	testImplementation "org.testcontainers:testcontainers-postgresql:2.0.1"
 	testImplementation "com.redis:testcontainers-redis:2.2.2"
+	testImplementation "org.testcontainers:kafka:1.20.1"
 	testImplementation "org.testcontainers:testcontainers-localstack:2.0.1"
 	testImplementation "org.testcontainers:junit-jupiter:1.20.1"
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 
 	// TestFixtures
 	testFixturesImplementation 'org.testcontainers:testcontainers-postgresql:2.0.1'
 	testFixturesImplementation 'com.redis:testcontainers-redis:2.2.2'
+    testFixturesImplementation "org.testcontainers:kafka:1.20.1"
     testFixturesImplementation "org.testcontainers:testcontainers-localstack:2.0.1"
     testFixturesImplementation "org.testcontainers:junit-jupiter:1.20.1"
     testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaConfig.java
@@ -29,8 +29,8 @@ public class KafkaConfig {
     @Bean
     KafkaAdmin.NewTopics chatMessageTopic(KafkaMessagingProperties properties) {
         return new KafkaAdmin.NewTopics(
-            new NewTopic(resolveTopic(properties.topics().chatMessage()), 3, (short) 1),
-            new NewTopic(resolveTopic(properties.topics().readReceipt()), 3, (short) 1)
+            new NewTopic(resolveTopic(properties.topics().chatMessage()), properties.partitionCount(), properties.replicationFactor()),
+            new NewTopic(resolveTopic(properties.topics().readReceipt()), properties.partitionCount(), properties.replicationFactor())
         );
     }
 

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaConfig.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -20,11 +19,8 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.util.StringUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 @EnableConfigurationProperties(KafkaMessagingProperties.class)
@@ -56,21 +52,11 @@ public class KafkaConfig {
     @Bean
     ConsumerFactory<String, Object> kafkaConsumerFactory(
         KafkaProperties kafkaProperties,
-        KafkaMessagingProperties messagingProperties,
-        ObjectMapper objectMapper
+        KafkaMessagingProperties messagingProperties
     ) {
         Map<String, Object> properties = new HashMap<>(kafkaProperties.buildConsumerProperties());
         properties.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, resolveConsumerGroup(messagingProperties));
-        properties.putIfAbsent(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-
-        JsonDeserializer<Object> valueDeserializer = new JsonDeserializer<>(Object.class, objectMapper, false);
-        valueDeserializer.addTrustedPackages("*");
-
-        return new DefaultKafkaConsumerFactory<>(
-            properties,
-            new StringDeserializer(),
-            valueDeserializer
-        );
+        return new DefaultKafkaConsumerFactory<>(properties);
     }
 
     @Bean

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaConfig.java
@@ -26,13 +26,11 @@ import org.springframework.util.StringUtils;
 @EnableConfigurationProperties(KafkaMessagingProperties.class)
 public class KafkaConfig {
 
-    private static final String DEFAULT_CHAT_MESSAGE_TOPIC = "qootalk.chat.message";
-    private static final String DEFAULT_CONSUMER_GROUP = "qootalk-chat";
-
     @Bean
     KafkaAdmin.NewTopics chatMessageTopic(KafkaMessagingProperties properties) {
         return new KafkaAdmin.NewTopics(
-            new NewTopic(resolveChatMessageTopic(properties), 3, (short) 1)
+            new NewTopic(resolveTopic(properties.topics().chatMessage()), 3, (short) 1),
+            new NewTopic(resolveTopic(properties.topics().readReceipt()), 3, (short) 1)
         );
     }
 
@@ -69,18 +67,16 @@ public class KafkaConfig {
         return factory;
     }
 
-    private String resolveChatMessageTopic(KafkaMessagingProperties properties) {
-        return Optional.ofNullable(properties)
-            .map(KafkaMessagingProperties::topics)
-            .map(KafkaMessagingProperties.Topics::chatMessage)
+    private String resolveTopic(String topic) {
+        return Optional.ofNullable(topic)
             .filter(StringUtils::hasText)
-            .orElse(DEFAULT_CHAT_MESSAGE_TOPIC);
+            .orElseThrow(() -> new IllegalStateException("Kafka topic must not be blank"));
     }
 
     private String resolveConsumerGroup(KafkaMessagingProperties properties) {
         return Optional.ofNullable(properties)
             .map(KafkaMessagingProperties::consumerGroup)
             .filter(StringUtils::hasText)
-            .orElse(DEFAULT_CONSUMER_GROUP);
+            .orElse(properties.consumerGroup());
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,100 @@
+package com.lrchan.qootalk.infrastructure.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+@EnableConfigurationProperties(KafkaMessagingProperties.class)
+public class KafkaConfig {
+
+    private static final String DEFAULT_CHAT_MESSAGE_TOPIC = "qootalk.chat.message";
+    private static final String DEFAULT_CONSUMER_GROUP = "qootalk-chat";
+
+    @Bean
+    KafkaAdmin.NewTopics chatMessageTopic(KafkaMessagingProperties properties) {
+        return new KafkaAdmin.NewTopics(
+            new NewTopic(resolveChatMessageTopic(properties), 3, (short) 1)
+        );
+    }
+
+    @Bean
+    ProducerFactory<String, Object> kafkaProducerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> properties = new HashMap<>(kafkaProperties.buildProducerProperties());
+        properties.putIfAbsent(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        properties.putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(properties);
+    }
+
+    @Bean
+    KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+
+    @Bean
+    ConsumerFactory<String, Object> kafkaConsumerFactory(
+        KafkaProperties kafkaProperties,
+        KafkaMessagingProperties messagingProperties,
+        ObjectMapper objectMapper
+    ) {
+        Map<String, Object> properties = new HashMap<>(kafkaProperties.buildConsumerProperties());
+        properties.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, resolveConsumerGroup(messagingProperties));
+        properties.putIfAbsent(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        JsonDeserializer<Object> valueDeserializer = new JsonDeserializer<>(Object.class, objectMapper, false);
+        valueDeserializer.addTrustedPackages("*");
+
+        return new DefaultKafkaConsumerFactory<>(
+            properties,
+            new StringDeserializer(),
+            valueDeserializer
+        );
+    }
+
+    @Bean
+    ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
+        ConsumerFactory<String, Object> consumerFactory
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        return factory;
+    }
+
+    private String resolveChatMessageTopic(KafkaMessagingProperties properties) {
+        return Optional.ofNullable(properties)
+            .map(KafkaMessagingProperties::topics)
+            .map(KafkaMessagingProperties.Topics::chatMessage)
+            .filter(StringUtils::hasText)
+            .orElse(DEFAULT_CHAT_MESSAGE_TOPIC);
+    }
+
+    private String resolveConsumerGroup(KafkaMessagingProperties properties) {
+        return Optional.ofNullable(properties)
+            .map(KafkaMessagingProperties::consumerGroup)
+            .filter(StringUtils::hasText)
+            .orElse(DEFAULT_CONSUMER_GROUP);
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaMessagingProperties.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaMessagingProperties.java
@@ -9,7 +9,8 @@ public record KafkaMessagingProperties(
 ) {
 
     public record Topics(
-        String chatMessage
+        String chatMessage,
+        String readReceipt
     ) {
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaMessagingProperties.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaMessagingProperties.java
@@ -5,7 +5,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "messaging.kafka")
 public record KafkaMessagingProperties(
     Topics topics,
-    String consumerGroup
+    String consumerGroup,
+    int partitionCount,
+    short replicationFactor
 ) {
 
     public record Topics(

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaMessagingProperties.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/KafkaMessagingProperties.java
@@ -1,0 +1,15 @@
+package com.lrchan.qootalk.infrastructure.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "messaging.kafka")
+public record KafkaMessagingProperties(
+    Topics topics,
+    String consumerGroup
+) {
+
+    public record Topics(
+        String chatMessage
+    ) {
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisMessagingProperties.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisMessagingProperties.java
@@ -10,6 +10,7 @@ public record RedisMessagingProperties(
 
     public record Channels(
         String chatMessage,
+        String readReceipt,
         String userPresence
     ) {
     }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisMessagingProperties.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisMessagingProperties.java
@@ -1,0 +1,16 @@
+package com.lrchan.qootalk.infrastructure.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "messaging.redis")
+public record RedisMessagingProperties(
+    Channels channels,
+    long presenceTtlSeconds
+) {
+
+    public record Channels(
+        String chatMessage,
+        String userPresence
+    ) {
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisPubSubConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisPubSubConfig.java
@@ -1,44 +1,34 @@
 package com.lrchan.qootalk.infrastructure.config;
 
 import java.time.Duration;
-import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.util.StringUtils;
+
+import com.lrchan.qootalk.infrastructure.messaging.redis.MessagePublisher;
+import com.lrchan.qootalk.infrastructure.messaging.redis.RedisMessagePublisher;
 
 @Configuration
 @EnableConfigurationProperties(RedisMessagingProperties.class)
 public class RedisPubSubConfig {
 
-    @Value("${qootalk.channels.chat-message}")
-    private String chatMessageChannel;
-
-    @Value("${qootalk.channels.user-presence}")
-    private String userPresenceChannel;
-
-    @Value("${qootalk.presence-ttl-seconds}")
-    private long presenceTtlSeconds;
-
     @Bean
     ChannelTopic chatMessageChannelTopic(RedisMessagingProperties properties) {
-        return new ChannelTopic(resolveChatMessageChannel(properties));
+        return new ChannelTopic(properties.channels().chatMessage());
     }
 
     @Bean
     ChannelTopic userPresenceChannelTopic(RedisMessagingProperties properties) {
-        return new ChannelTopic(resolveUserPresenceChannel(properties));
+        return new ChannelTopic(properties.channels().userPresence());
     }
 
     @Bean
-    RedisMessageListenerContainer redisMessageListenerContainer(
-        org.springframework.data.redis.connection.RedisConnectionFactory connectionFactory
-    ) {
+    RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
         return container;
@@ -46,51 +36,11 @@ public class RedisPubSubConfig {
 
     @Bean
     Duration userPresenceTtl(RedisMessagingProperties properties) {
-        return Duration.ofSeconds(resolvePresenceTtlSeconds(properties));
+        return Duration.ofSeconds(properties.presenceTtlSeconds());
     }
 
     @Bean
     MessagePublisher redisMessagePublisher(RedisTemplate<String, Object> redisTemplate) {
         return new RedisMessagePublisher(redisTemplate);
-    }
-
-    public interface MessagePublisher {
-        void publish(ChannelTopic topic, Object payload);
-    }
-
-    static class RedisMessagePublisher implements MessagePublisher {
-        private final RedisTemplate<String, Object> redisTemplate;
-
-        RedisMessagePublisher(RedisTemplate<String, Object> redisTemplate) {
-            this.redisTemplate = redisTemplate;
-        }
-
-        @Override
-        public void publish(ChannelTopic topic, Object payload) {
-            redisTemplate.convertAndSend(topic.getTopic(), payload);
-        }
-    }
-
-    private String resolveChatMessageChannel(RedisMessagingProperties properties) {
-        return Optional.ofNullable(properties)
-            .map(RedisMessagingProperties::channels)
-            .map(RedisMessagingProperties.Channels::chatMessage)
-            .filter(StringUtils::hasText)
-            .orElse(chatMessageChannel);
-    }
-
-    private String resolveUserPresenceChannel(RedisMessagingProperties properties) {
-        return Optional.ofNullable(properties)
-            .map(RedisMessagingProperties::channels)
-            .map(RedisMessagingProperties.Channels::userPresence)
-            .filter(StringUtils::hasText)
-            .orElse(userPresenceChannel);
-    }
-
-    private long resolvePresenceTtlSeconds(RedisMessagingProperties properties) {
-        return Optional.ofNullable(properties)
-            .map(RedisMessagingProperties::presenceTtlSeconds)
-            .filter(ttl -> ttl > 0)
-            .orElse(presenceTtlSeconds);
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisPubSubConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisPubSubConfig.java
@@ -3,6 +3,7 @@ package com.lrchan.qootalk.infrastructure.config;
 import java.time.Duration;
 import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,9 +16,14 @@ import org.springframework.util.StringUtils;
 @EnableConfigurationProperties(RedisMessagingProperties.class)
 public class RedisPubSubConfig {
 
-    private static final String DEFAULT_CHAT_MESSAGE_CHANNEL = "qootalk:chat:message";
-    private static final String DEFAULT_USER_PRESENCE_CHANNEL = "qootalk:user:presence";
-    private static final long DEFAULT_USER_PRESENCE_TTL_SECONDS = 300L;
+    @Value("${qootalk.channels.chat-message}")
+    private String chatMessageChannel;
+
+    @Value("${qootalk.channels.user-presence}")
+    private String userPresenceChannel;
+
+    @Value("${qootalk.presence-ttl-seconds}")
+    private long presenceTtlSeconds;
 
     @Bean
     ChannelTopic chatMessageChannelTopic(RedisMessagingProperties properties) {
@@ -70,7 +76,7 @@ public class RedisPubSubConfig {
             .map(RedisMessagingProperties::channels)
             .map(RedisMessagingProperties.Channels::chatMessage)
             .filter(StringUtils::hasText)
-            .orElse(DEFAULT_CHAT_MESSAGE_CHANNEL);
+            .orElse(chatMessageChannel);
     }
 
     private String resolveUserPresenceChannel(RedisMessagingProperties properties) {
@@ -78,13 +84,13 @@ public class RedisPubSubConfig {
             .map(RedisMessagingProperties::channels)
             .map(RedisMessagingProperties.Channels::userPresence)
             .filter(StringUtils::hasText)
-            .orElse(DEFAULT_USER_PRESENCE_CHANNEL);
+            .orElse(userPresenceChannel);
     }
 
     private long resolvePresenceTtlSeconds(RedisMessagingProperties properties) {
         return Optional.ofNullable(properties)
             .map(RedisMessagingProperties::presenceTtlSeconds)
             .filter(ttl -> ttl > 0)
-            .orElse(DEFAULT_USER_PRESENCE_TTL_SECONDS);
+            .orElse(presenceTtlSeconds);
     }
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisPubSubConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisPubSubConfig.java
@@ -1,0 +1,90 @@
+package com.lrchan.qootalk.infrastructure.config;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.util.StringUtils;
+
+@Configuration
+@EnableConfigurationProperties(RedisMessagingProperties.class)
+public class RedisPubSubConfig {
+
+    private static final String DEFAULT_CHAT_MESSAGE_CHANNEL = "qootalk:chat:message";
+    private static final String DEFAULT_USER_PRESENCE_CHANNEL = "qootalk:user:presence";
+    private static final long DEFAULT_USER_PRESENCE_TTL_SECONDS = 300L;
+
+    @Bean
+    ChannelTopic chatMessageChannelTopic(RedisMessagingProperties properties) {
+        return new ChannelTopic(resolveChatMessageChannel(properties));
+    }
+
+    @Bean
+    ChannelTopic userPresenceChannelTopic(RedisMessagingProperties properties) {
+        return new ChannelTopic(resolveUserPresenceChannel(properties));
+    }
+
+    @Bean
+    RedisMessageListenerContainer redisMessageListenerContainer(
+        org.springframework.data.redis.connection.RedisConnectionFactory connectionFactory
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
+
+    @Bean
+    Duration userPresenceTtl(RedisMessagingProperties properties) {
+        return Duration.ofSeconds(resolvePresenceTtlSeconds(properties));
+    }
+
+    @Bean
+    MessagePublisher redisMessagePublisher(StringRedisTemplate redisTemplate) {
+        return new RedisMessagePublisher(redisTemplate);
+    }
+
+    public interface MessagePublisher {
+        void publish(ChannelTopic topic, Object payload);
+    }
+
+    static class RedisMessagePublisher implements MessagePublisher {
+        private final StringRedisTemplate redisTemplate;
+
+        RedisMessagePublisher(StringRedisTemplate redisTemplate) {
+            this.redisTemplate = redisTemplate;
+        }
+
+        @Override
+        public void publish(ChannelTopic topic, Object payload) {
+            redisTemplate.convertAndSend(topic.getTopic(), payload);
+        }
+    }
+
+    private String resolveChatMessageChannel(RedisMessagingProperties properties) {
+        return Optional.ofNullable(properties)
+            .map(RedisMessagingProperties::channels)
+            .map(RedisMessagingProperties.Channels::chatMessage)
+            .filter(StringUtils::hasText)
+            .orElse(DEFAULT_CHAT_MESSAGE_CHANNEL);
+    }
+
+    private String resolveUserPresenceChannel(RedisMessagingProperties properties) {
+        return Optional.ofNullable(properties)
+            .map(RedisMessagingProperties::channels)
+            .map(RedisMessagingProperties.Channels::userPresence)
+            .filter(StringUtils::hasText)
+            .orElse(DEFAULT_USER_PRESENCE_CHANNEL);
+    }
+
+    private long resolvePresenceTtlSeconds(RedisMessagingProperties properties) {
+        return Optional.ofNullable(properties)
+            .map(RedisMessagingProperties::presenceTtlSeconds)
+            .filter(ttl -> ttl > 0)
+            .orElse(DEFAULT_USER_PRESENCE_TTL_SECONDS);
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisPubSubConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisPubSubConfig.java
@@ -23,6 +23,11 @@ public class RedisPubSubConfig {
     }
 
     @Bean
+    ChannelTopic readReceiptChannelTopic(RedisMessagingProperties properties) {
+        return new ChannelTopic(properties.channels().readReceipt());
+    }
+
+    @Bean
     ChannelTopic userPresenceChannelTopic(RedisMessagingProperties properties) {
         return new ChannelTopic(properties.channels().userPresence());
     }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisPubSubConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/RedisPubSubConfig.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.util.StringUtils;
@@ -44,7 +44,7 @@ public class RedisPubSubConfig {
     }
 
     @Bean
-    MessagePublisher redisMessagePublisher(StringRedisTemplate redisTemplate) {
+    MessagePublisher redisMessagePublisher(RedisTemplate<String, Object> redisTemplate) {
         return new RedisMessagePublisher(redisTemplate);
     }
 
@@ -53,9 +53,9 @@ public class RedisPubSubConfig {
     }
 
     static class RedisMessagePublisher implements MessagePublisher {
-        private final StringRedisTemplate redisTemplate;
+        private final RedisTemplate<String, Object> redisTemplate;
 
-        RedisMessagePublisher(StringRedisTemplate redisTemplate) {
+        RedisMessagePublisher(RedisTemplate<String, Object> redisTemplate) {
             this.redisTemplate = redisTemplate;
         }
 

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/SchedulingConfig.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.lrchan.qootalk.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ChatMessageKafkaListener.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ChatMessageKafkaListener.java
@@ -1,0 +1,46 @@
+package com.lrchan.qootalk.infrastructure.messaging.kafka;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.lrchan.qootalk.application.chat.dto.event.ChatMessageEvent;
+import com.lrchan.qootalk.application.chat.dto.event.UserChatMessageEvent;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.infrastructure.config.RedisPubSubConfig.MessagePublisher;
+import com.lrchan.qootalk.infrastructure.messaging.presence.RedisUserPresenceTracker;
+
+@Component
+public class ChatMessageKafkaListener {
+
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+    private final RedisUserPresenceTracker redisUserPresenceTracker;
+    private final MessagePublisher messagePublisher;
+    private final ChannelTopic chatMessageChannelTopic;
+
+    public ChatMessageKafkaListener(
+        LoadRoomParticipantPort loadRoomParticipantPort,
+        RedisUserPresenceTracker redisUserPresenceTracker,
+        MessagePublisher messagePublisher,
+        @Qualifier("chatMessageChannelTopic") ChannelTopic chatMessageChannelTopic
+    ) {
+        this.loadRoomParticipantPort = loadRoomParticipantPort;
+        this.redisUserPresenceTracker = redisUserPresenceTracker;
+        this.messagePublisher = messagePublisher;
+        this.chatMessageChannelTopic = chatMessageChannelTopic;
+    }
+
+    @KafkaListener(
+        topics = "${messaging.kafka.topics.chat-message:qootalk.chat.message}",
+        groupId = "${messaging.kafka.consumer-group:qootalk-chat}",
+        containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onMessage(ChatMessageEvent event) {
+        loadRoomParticipantPort.findActiveByRoomId(event.roomId()).stream()
+            .map(participant -> participant.userId())
+            .filter(redisUserPresenceTracker::isConnected)
+            .map(userId -> new UserChatMessageEvent(userId, event))
+            .forEach(userEvent -> messagePublisher.publish(chatMessageChannelTopic, userEvent));
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ChatMessageKafkaListener.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ChatMessageKafkaListener.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import com.lrchan.qootalk.application.chat.dto.event.ChatMessageEvent;
 import com.lrchan.qootalk.application.chat.dto.event.UserChatMessageEvent;
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
-import com.lrchan.qootalk.infrastructure.config.RedisPubSubConfig.MessagePublisher;
+import com.lrchan.qootalk.infrastructure.messaging.redis.MessagePublisher;
 import com.lrchan.qootalk.infrastructure.messaging.presence.RedisUserPresenceTracker;
 
 @Component

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/kafka/KafkaChatMessagePublisher.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/kafka/KafkaChatMessagePublisher.java
@@ -1,0 +1,27 @@
+package com.lrchan.qootalk.infrastructure.messaging.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.lrchan.qootalk.application.chat.dto.event.ChatMessageEvent;
+import com.lrchan.qootalk.application.chat.port.out.PublishChatMessagePort;
+import com.lrchan.qootalk.infrastructure.config.KafkaMessagingProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaChatMessagePublisher implements PublishChatMessagePort {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaMessagingProperties kafkaMessagingProperties;
+
+    @Override
+    public void publish(ChatMessageEvent event) {
+        kafkaTemplate.send(
+            kafkaMessagingProperties.topics().chatMessage(),
+            String.valueOf(event.roomId()),
+            event
+        );
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/kafka/KafkaReadReceiptPublisher.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/kafka/KafkaReadReceiptPublisher.java
@@ -1,0 +1,27 @@
+package com.lrchan.qootalk.infrastructure.messaging.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.lrchan.qootalk.application.chat.dto.event.ReadReceiptEvent;
+import com.lrchan.qootalk.application.chat.port.out.PublishReadReceiptPort;
+import com.lrchan.qootalk.infrastructure.config.KafkaMessagingProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaReadReceiptPublisher implements PublishReadReceiptPort {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaMessagingProperties kafkaMessagingProperties;
+
+    @Override
+    public void publish(ReadReceiptEvent event) {
+        kafkaTemplate.send(
+            kafkaMessagingProperties.topics().readReceipt(),
+            String.valueOf(event.roomId()),
+            event
+        );
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ReadReceiptKafkaListener.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ReadReceiptKafkaListener.java
@@ -1,0 +1,47 @@
+package com.lrchan.qootalk.infrastructure.messaging.kafka;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.lrchan.qootalk.application.chat.dto.event.ReadReceiptEvent;
+import com.lrchan.qootalk.application.chat.dto.event.UserReadReceiptEvent;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.infrastructure.messaging.presence.RedisUserPresenceTracker;
+import com.lrchan.qootalk.infrastructure.messaging.redis.MessagePublisher;
+
+@Component
+public class ReadReceiptKafkaListener {
+
+    private final LoadRoomParticipantPort loadRoomParticipantPort;
+    private final RedisUserPresenceTracker redisUserPresenceTracker;
+    private final MessagePublisher messagePublisher;
+    private final ChannelTopic readReceiptChannelTopic;
+
+    public ReadReceiptKafkaListener(
+        LoadRoomParticipantPort loadRoomParticipantPort,
+        RedisUserPresenceTracker redisUserPresenceTracker,
+        MessagePublisher messagePublisher,
+        @Qualifier("readReceiptChannelTopic") ChannelTopic readReceiptChannelTopic
+    ) {
+        this.loadRoomParticipantPort = loadRoomParticipantPort;
+        this.redisUserPresenceTracker = redisUserPresenceTracker;
+        this.messagePublisher = messagePublisher;
+        this.readReceiptChannelTopic = readReceiptChannelTopic;
+    }
+
+    @KafkaListener(
+        topics = "${messaging.kafka.topics.read-receipt:qootalk.read.receipt}",
+        groupId = "${messaging.kafka.consumer-group:qootalk-chat}",
+        containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onMessage(ReadReceiptEvent event) {
+        loadRoomParticipantPort.findActiveByRoomId(event.roomId()).stream()
+            .map(participant -> participant.userId())
+            .filter(userId -> !userId.equals(event.readerId()))
+            .filter(redisUserPresenceTracker::isConnected)
+            .map(userId -> new UserReadReceiptEvent(userId, event))
+            .forEach(userEvent -> messagePublisher.publish(readReceiptChannelTopic, userEvent));
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/presence/LocalUserConnectionRegistry.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/presence/LocalUserConnectionRegistry.java
@@ -40,6 +40,10 @@ public class LocalUserConnectionRegistry {
     }
 
     public void dispatch(Long userId, ChatMessageEvent event) {
+        dispatch(userId, "chat-message", String.valueOf(event.messageId()), event);
+    }
+
+    public void dispatch(Long userId, String eventName, String eventId, Object payload) {
         Map<String, SseEmitter> emitters = emittersByUser.get(userId);
         if (emitters == null || emitters.isEmpty()) {
             return;
@@ -47,10 +51,15 @@ public class LocalUserConnectionRegistry {
 
         emitters.forEach((connectionId, emitter) -> {
             try {
-                emitter.send(SseEmitter.event()
-                    .name("chat-message")
-                    .id(String.valueOf(event.messageId()))
-                    .data(event));
+                SseEmitter.SseEventBuilder event = SseEmitter.event()
+                    .name(eventName)
+                    .data(payload);
+
+                if (eventId != null) {
+                    event.id(eventId);
+                }
+
+                emitter.send(event);
             } catch (IOException ex) {
                 remove(userId, connectionId);
                 emitter.completeWithError(ex);

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/presence/LocalUserConnectionRegistry.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/presence/LocalUserConnectionRegistry.java
@@ -1,0 +1,95 @@
+package com.lrchan.qootalk.infrastructure.messaging.presence;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.lrchan.qootalk.application.chat.dto.event.ChatMessageEvent;
+
+@Component
+public class LocalUserConnectionRegistry {
+
+    private final Map<Long, Map<String, SseEmitter>> emittersByUser = new ConcurrentHashMap<>();
+
+    public Connection register(Long userId) {
+        String connectionId = UUID.randomUUID().toString();
+        SseEmitter emitter = new SseEmitter(0L);
+
+        emittersByUser
+            .computeIfAbsent(userId, ignored -> new ConcurrentHashMap<>())
+            .put(connectionId, emitter);
+
+        return new Connection(userId, connectionId, emitter);
+    }
+
+    public void remove(Long userId, String connectionId) {
+        Map<String, SseEmitter> emitters = emittersByUser.get(userId);
+        if (emitters == null) {
+            return;
+        }
+
+        emitters.remove(connectionId);
+        if (emitters.isEmpty()) {
+            emittersByUser.remove(userId);
+        }
+    }
+
+    public void dispatch(Long userId, ChatMessageEvent event) {
+        Map<String, SseEmitter> emitters = emittersByUser.get(userId);
+        if (emitters == null || emitters.isEmpty()) {
+            return;
+        }
+
+        emitters.forEach((connectionId, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                    .name("chat-message")
+                    .id(String.valueOf(event.messageId()))
+                    .data(event));
+            } catch (IOException ex) {
+                remove(userId, connectionId);
+                emitter.completeWithError(ex);
+            }
+        });
+    }
+
+    public void sendHeartbeat(Long userId, String connectionId) {
+        Map<String, SseEmitter> emitters = emittersByUser.get(userId);
+        if (emitters == null) {
+            return;
+        }
+
+        SseEmitter emitter = emitters.get(connectionId);
+        if (emitter == null) {
+            return;
+        }
+
+        try {
+            emitter.send(SseEmitter.event()
+                .name("heartbeat")
+                .data("ping"));
+        } catch (IOException ex) {
+            remove(userId, connectionId);
+            emitter.completeWithError(ex);
+        }
+    }
+
+    public Set<ConnectionRef> activeConnections() {
+        Set<ConnectionRef> refs = ConcurrentHashMap.newKeySet();
+        emittersByUser.forEach((userId, emitters) ->
+            emitters.keySet().forEach(connectionId -> refs.add(new ConnectionRef(userId, connectionId)))
+        );
+        return refs;
+    }
+
+    public record Connection(Long userId, String connectionId, SseEmitter emitter) {
+    }
+
+    public record ConnectionRef(Long userId, String connectionId) {
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/presence/RedisUserPresenceTracker.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/presence/RedisUserPresenceTracker.java
@@ -1,0 +1,52 @@
+package com.lrchan.qootalk.infrastructure.messaging.presence;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUserPresenceTracker {
+
+    private static final String USER_PRESENCE_KEY_PREFIX = "qootalk:user:presence:";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final Duration userPresenceTtl;
+
+    public void markConnected(Long userId, String connectionId) {
+        String key = presenceKey(userId, connectionId);
+        stringRedisTemplate.opsForValue().set(key, "ONLINE", userPresenceTtl);
+    }
+
+    public void refreshConnection(Long userId, String connectionId) {
+        String key = presenceKey(userId, connectionId);
+        stringRedisTemplate.expire(key, userPresenceTtl);
+    }
+
+    public void disconnect(Long userId, String connectionId) {
+        stringRedisTemplate.delete(presenceKey(userId, connectionId));
+    }
+
+    public boolean isConnected(Long userId) {
+        ScanOptions options = ScanOptions.scanOptions()
+            .match(USER_PRESENCE_KEY_PREFIX + userId + ":*")
+            .count(20)
+            .build();
+
+        return Boolean.TRUE.equals(stringRedisTemplate.execute((RedisCallback<Boolean>) connection -> {
+            try (Cursor<byte[]> cursor = connection.scan(options)) {
+                return cursor.hasNext();
+            }
+        }));
+    }
+
+    private String presenceKey(Long userId, String connectionId) {
+        return USER_PRESENCE_KEY_PREFIX + userId + ":" + connectionId;
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/presence/UserPresenceHeartbeatScheduler.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/presence/UserPresenceHeartbeatScheduler.java
@@ -1,0 +1,22 @@
+package com.lrchan.qootalk.infrastructure.messaging.presence;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserPresenceHeartbeatScheduler {
+
+    private final LocalUserConnectionRegistry localUserConnectionRegistry;
+    private final RedisUserPresenceTracker redisUserPresenceTracker;
+
+    @Scheduled(fixedDelayString = "${messaging.redis.presence-heartbeat-millis:60000}")
+    public void refreshPresence() {
+        for (LocalUserConnectionRegistry.ConnectionRef connection : localUserConnectionRegistry.activeConnections()) {
+            redisUserPresenceTracker.refreshConnection(connection.userId(), connection.connectionId());
+            localUserConnectionRegistry.sendHeartbeat(connection.userId(), connection.connectionId());
+        }
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/redis/MessagePublisher.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/redis/MessagePublisher.java
@@ -1,0 +1,7 @@
+package com.lrchan.qootalk.infrastructure.messaging.redis;
+
+import org.springframework.data.redis.listener.ChannelTopic;
+
+public interface MessagePublisher {
+    void publish(ChannelTopic topic, Object payload);
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/redis/RedisChatMessageSubscriber.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/redis/RedisChatMessageSubscriber.java
@@ -1,0 +1,49 @@
+package com.lrchan.qootalk.infrastructure.messaging.redis;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.lrchan.qootalk.application.chat.dto.event.UserChatMessageEvent;
+import com.lrchan.qootalk.infrastructure.messaging.presence.LocalUserConnectionRegistry;
+
+@Component
+public class RedisChatMessageSubscriber implements MessageListener, InitializingBean {
+
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final ChannelTopic chatMessageChannelTopic;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final LocalUserConnectionRegistry localUserConnectionRegistry;
+
+    public RedisChatMessageSubscriber(
+        RedisMessageListenerContainer redisMessageListenerContainer,
+        @Qualifier("chatMessageChannelTopic") ChannelTopic chatMessageChannelTopic,
+        RedisTemplate<String, Object> redisTemplate,
+        LocalUserConnectionRegistry localUserConnectionRegistry
+    ) {
+        this.redisMessageListenerContainer = redisMessageListenerContainer;
+        this.chatMessageChannelTopic = chatMessageChannelTopic;
+        this.redisTemplate = redisTemplate;
+        this.localUserConnectionRegistry = localUserConnectionRegistry;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        redisMessageListenerContainer.addMessageListener(this, chatMessageChannelTopic);
+    }
+
+    @Override
+    public void onMessage(org.springframework.data.redis.connection.Message message, byte[] pattern) {
+        RedisSerializer<?> serializer = redisTemplate.getValueSerializer();
+        Object payload = serializer.deserialize(message.getBody());
+        if (!(payload instanceof UserChatMessageEvent userEvent)) {
+            return;
+        }
+        localUserConnectionRegistry.dispatch(userEvent.recipientId(), userEvent.message());
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/redis/RedisMessagePublisher.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/redis/RedisMessagePublisher.java
@@ -1,0 +1,16 @@
+package com.lrchan.qootalk.infrastructure.messaging.redis;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RedisMessagePublisher implements MessagePublisher {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public void publish(ChannelTopic topic, Object payload) {
+        redisTemplate.convertAndSend(topic.getTopic(), payload);
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/redis/RedisReadReceiptSubscriber.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/messaging/redis/RedisReadReceiptSubscriber.java
@@ -1,0 +1,55 @@
+package com.lrchan.qootalk.infrastructure.messaging.redis;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.stereotype.Component;
+
+import com.lrchan.qootalk.application.chat.dto.event.UserReadReceiptEvent;
+import com.lrchan.qootalk.infrastructure.messaging.presence.LocalUserConnectionRegistry;
+
+@Component
+public class RedisReadReceiptSubscriber implements MessageListener, InitializingBean {
+
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final ChannelTopic readReceiptChannelTopic;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final LocalUserConnectionRegistry localUserConnectionRegistry;
+
+    public RedisReadReceiptSubscriber(
+        RedisMessageListenerContainer redisMessageListenerContainer,
+        @Qualifier("readReceiptChannelTopic") ChannelTopic readReceiptChannelTopic,
+        RedisTemplate<String, Object> redisTemplate,
+        LocalUserConnectionRegistry localUserConnectionRegistry
+    ) {
+        this.redisMessageListenerContainer = redisMessageListenerContainer;
+        this.readReceiptChannelTopic = readReceiptChannelTopic;
+        this.redisTemplate = redisTemplate;
+        this.localUserConnectionRegistry = localUserConnectionRegistry;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        redisMessageListenerContainer.addMessageListener(this, readReceiptChannelTopic);
+    }
+
+    @Override
+    public void onMessage(org.springframework.data.redis.connection.Message message, byte[] pattern) {
+        RedisSerializer<?> serializer = redisTemplate.getValueSerializer();
+        Object payload = serializer.deserialize(message.getBody());
+        if (!(payload instanceof UserReadReceiptEvent userEvent)) {
+            return;
+        }
+
+        localUserConnectionRegistry.dispatch(
+            userEvent.recipientId(),
+            "read-receipt",
+            String.valueOf(userEvent.readReceipt().lastReadMessageId()),
+            userEvent.readReceipt()
+        );
+    }
+}

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageJpaRepository.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageJpaRepository.java
@@ -1,5 +1,7 @@
 package com.lrchan.qootalk.infrastructure.persistence.chat.message;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -7,4 +9,17 @@ import org.springframework.data.repository.query.Param;
 public interface MessageJpaRepository extends JpaRepository<MessageEntity, Long> {
     @Query("SELECT COUNT(*) FROM MessageEntity WHERE roomId = :roomId AND id > :id")
     Long countByRoomIdAndIdAfter(@Param("roomId") Long roomId, @Param("id") Long id);
+
+    @Query("""
+        SELECT m
+        FROM MessageEntity m
+        WHERE m.roomId = :roomId
+          AND (:fromMessageId IS NULL OR m.id < :fromMessageId)
+        ORDER BY m.id DESC
+        """)
+    Slice<MessageEntity> findSliceByRoomId(
+        @Param("roomId") Long roomId,
+        @Param("fromMessageId") Long fromMessageId,
+        Pageable pageable
+    );
 }

--- a/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageRepositoryAdapter.java
+++ b/qootalk-server/module-infrastructure/src/main/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageRepositoryAdapter.java
@@ -3,6 +3,8 @@ package com.lrchan.qootalk.infrastructure.persistence.chat.message;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import com.lrchan.qootalk.application.chat.port.out.LoadMessagePort;
@@ -33,5 +35,11 @@ public class MessageRepositoryAdapter implements MessageRepository, SaveMessageP
     @Override
     public Long countByRoomIdAndIdAfter(Long roomId, Long id) {
         return messageJpaRepository.countByRoomIdAndIdAfter(roomId, id);
+    }
+
+    @Override
+    public Slice<Message> findSliceByRoomId(Long roomId, Long fromMessageId, int page, int size) {
+        return messageJpaRepository.findSliceByRoomId(roomId, fromMessageId, PageRequest.of(page, size))
+            .map(MessageEntityMapper::toDomain);
     }
 }

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ChatMessageKafkaListenerTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ChatMessageKafkaListenerTest.java
@@ -1,0 +1,70 @@
+package com.lrchan.qootalk.infrastructure.messaging.kafka;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.listener.ChannelTopic;
+
+import com.lrchan.qootalk.application.chat.dto.event.ChatMessageEvent;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+import com.lrchan.qootalk.infrastructure.config.RedisPubSubConfig.MessagePublisher;
+import com.lrchan.qootalk.infrastructure.messaging.presence.RedisUserPresenceTracker;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageKafkaListenerTest {
+
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+    @Mock
+    private RedisUserPresenceTracker redisUserPresenceTracker;
+    @Mock
+    private MessagePublisher messagePublisher;
+    @Mock
+    private ChannelTopic chatMessageChannelTopic;
+
+    @InjectMocks
+    private ChatMessageKafkaListener chatMessageKafkaListener;
+
+    @Test
+    @DisplayName("Kafka 메시지를 수신하면 현재 접속 중인 참여자에게만 Redis 이벤트를 발행한다")
+    void onMessage_publishOnlyConnectedParticipants() {
+        ChatMessageEvent event = new ChatMessageEvent(
+            100L,
+            10L,
+            1L,
+            "안녕하세요",
+            MessageType.TEXT,
+            List.of(),
+            null,
+            List.of(),
+            LocalDateTime.now()
+        );
+
+        given(loadRoomParticipantPort.findActiveByRoomId(10L)).willReturn(List.of(
+            com.lrchan.qootalk.domain.chat.participant.RoomParticipant.reconstruct(1L, 1L, 10L, 99L, RoomRole.MEMBER, LocalDateTime.now(), LocalDateTime.now(), null),
+            com.lrchan.qootalk.domain.chat.participant.RoomParticipant.reconstruct(2L, 2L, 10L, 99L, RoomRole.MEMBER, LocalDateTime.now(), LocalDateTime.now(), null),
+            com.lrchan.qootalk.domain.chat.participant.RoomParticipant.reconstruct(3L, 3L, 10L, 99L, RoomRole.MEMBER, LocalDateTime.now(), LocalDateTime.now(), null)
+        ));
+        given(redisUserPresenceTracker.isConnected(1L)).willReturn(true);
+        given(redisUserPresenceTracker.isConnected(2L)).willReturn(false);
+        given(redisUserPresenceTracker.isConnected(3L)).willReturn(true);
+
+        chatMessageKafkaListener.onMessage(event);
+
+        verify(messagePublisher, times(2)).publish(eq(chatMessageChannelTopic), any());
+    }
+}

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ChatMessageKafkaListenerTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ChatMessageKafkaListenerTest.java
@@ -21,7 +21,7 @@ import com.lrchan.qootalk.application.chat.dto.event.ChatMessageEvent;
 import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
 import com.lrchan.qootalk.domain.chat.message.MessageType;
 import com.lrchan.qootalk.domain.chat.participant.RoomRole;
-import com.lrchan.qootalk.infrastructure.config.RedisPubSubConfig.MessagePublisher;
+import com.lrchan.qootalk.infrastructure.messaging.redis.MessagePublisher;
 import com.lrchan.qootalk.infrastructure.messaging.presence.RedisUserPresenceTracker;
 
 @ExtendWith(MockitoExtension.class)

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ReadReceiptKafkaListenerTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/messaging/kafka/ReadReceiptKafkaListenerTest.java
@@ -1,0 +1,73 @@
+package com.lrchan.qootalk.infrastructure.messaging.kafka;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.listener.ChannelTopic;
+
+import com.lrchan.qootalk.application.chat.dto.event.ReadReceiptEvent;
+import com.lrchan.qootalk.application.chat.port.out.LoadRoomParticipantPort;
+import com.lrchan.qootalk.domain.chat.participant.RoomParticipant;
+import com.lrchan.qootalk.domain.chat.participant.RoomRole;
+import com.lrchan.qootalk.infrastructure.messaging.presence.RedisUserPresenceTracker;
+import com.lrchan.qootalk.infrastructure.messaging.redis.MessagePublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReadReceiptKafkaListenerTest {
+
+    @Mock
+    private LoadRoomParticipantPort loadRoomParticipantPort;
+    @Mock
+    private RedisUserPresenceTracker redisUserPresenceTracker;
+    @Mock
+    private MessagePublisher messagePublisher;
+    @Mock
+    private ChannelTopic readReceiptChannelTopic;
+
+    @InjectMocks
+    private ReadReceiptKafkaListener readReceiptKafkaListener;
+
+    @Test
+    @DisplayName("읽음 이벤트를 수신하면 현재 접속 중인 다른 참여자에게만 Redis 이벤트를 발행한다")
+    void onMessage_publishOnlyConnectedParticipantsExceptReader() {
+        ReadReceiptEvent event = new ReadReceiptEvent(10L, 1L, 100L, LocalDateTime.now());
+
+        given(loadRoomParticipantPort.findActiveByRoomId(10L)).willReturn(List.of(
+            participant(1L, 10L),
+            participant(2L, 10L),
+            participant(3L, 10L)
+        ));
+        given(redisUserPresenceTracker.isConnected(2L)).willReturn(true);
+        given(redisUserPresenceTracker.isConnected(3L)).willReturn(false);
+
+        readReceiptKafkaListener.onMessage(event);
+
+        verify(messagePublisher, times(1)).publish(eq(readReceiptChannelTopic), any());
+    }
+
+    private RoomParticipant participant(Long userId, Long roomId) {
+        return RoomParticipant.reconstruct(
+            userId,
+            userId,
+            roomId,
+            0L,
+            RoomRole.MEMBER,
+            true,
+            LocalDateTime.now().minusDays(1),
+            LocalDateTime.now().minusMinutes(1),
+            null
+        );
+    }
+}

--- a/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageJpaRepositoryTest.java
+++ b/qootalk-server/module-infrastructure/src/test/java/com/lrchan/qootalk/infrastructure/persistence/chat/message/MessageJpaRepositoryTest.java
@@ -3,6 +3,8 @@ package com.lrchan.qootalk.infrastructure.persistence.chat.message;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.lrchan.qootalk.domain.chat.message.MessageType;
@@ -38,5 +40,34 @@ public class MessageJpaRepositoryTest extends IntegrationTestSupport {
         assertThat(savedMessageEntity.getMessageType()).isEqualTo(MessageType.TEXT);
         assertThat(savedMessageEntity.getCreatedAt()).isNotNull();
         assertThat(savedMessageEntity.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("대량 메시지 환경에서도 roomId와 fromMessageId 기준 Slice 조회가 가능하다")
+    void should_sliceMessages_when_largeHistoryExists() {
+        for (int i = 1; i <= 120; i++) {
+            messageJpaRepository.save(MessageEntity.builder()
+                .roomId(10L)
+                .userId(2L)
+                .content("message-" + i)
+                .messageType(MessageType.TEXT)
+                .build());
+        }
+
+        Slice<MessageEntity> firstSlice = messageJpaRepository.findSliceByRoomId(10L, null, PageRequest.of(0, 20));
+
+        assertThat(firstSlice.getContent()).hasSize(20);
+        assertThat(firstSlice.hasNext()).isTrue();
+        assertThat(firstSlice.getContent().get(0).getContent()).isEqualTo("message-120");
+        assertThat(firstSlice.getContent().get(19).getContent()).isEqualTo("message-101");
+
+        Long fromMessageId = firstSlice.getContent().get(19).getId();
+
+        Slice<MessageEntity> secondSlice = messageJpaRepository.findSliceByRoomId(10L, fromMessageId, PageRequest.of(0, 20));
+
+        assertThat(secondSlice.getContent()).hasSize(20);
+        assertThat(secondSlice.hasNext()).isTrue();
+        assertThat(secondSlice.getContent().get(0).getContent()).isEqualTo("message-100");
+        assertThat(secondSlice.getContent().get(19).getContent()).isEqualTo("message-81");
     }
 }

--- a/qootalk-server/module-infrastructure/src/testFixtures/java/com/lrchan/qootalk/infrastructure/IntegrationTestSupport.java
+++ b/qootalk-server/module-infrastructure/src/testFixtures/java/com/lrchan/qootalk/infrastructure/IntegrationTestSupport.java
@@ -4,6 +4,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import com.redis.testcontainers.RedisContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.localstack.LocalStackContainer;
 import org.testcontainers.postgresql.PostgreSQLContainer;
@@ -15,6 +16,7 @@ public abstract class IntegrationTestSupport {
 
     static final PostgreSQLContainer postgres;
     static final RedisContainer redis;
+    static final KafkaContainer kafka;
     static final LocalStackContainer localstack;
 
     static {
@@ -22,8 +24,13 @@ public abstract class IntegrationTestSupport {
         localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0.0"))
             .withEnv("DEFAULT_REGION", "ap-northeast-2");
         redis = new RedisContainer(DockerImageName.parse("redis:7-alpine"));
+        kafka = new KafkaContainer(
+            DockerImageName.parse("apache/kafka-native:3.8.0")
+                .asCompatibleSubstituteFor("apache/kafka")
+        );
 
         redis.start();
+        kafka.start();
         postgres.start();
         localstack.start();
         
@@ -57,6 +64,7 @@ public abstract class IntegrationTestSupport {
         // --- Redis (Testcontainers) 설정 ---
         registry.add("spring.data.redis.host", redis::getHost);
         registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
 
         // --- JWT 설정 ---
         // 이 값은 테스트 코드에서 사용되는 임시 값이므로, 실제 개발 환경에서는 사용하지 않습니다.

--- a/qootalk-server/module-infrastructure/src/testFixtures/java/com/lrchan/qootalk/infrastructure/IntegrationTestSupport.java
+++ b/qootalk-server/module-infrastructure/src/testFixtures/java/com/lrchan/qootalk/infrastructure/IntegrationTestSupport.java
@@ -74,11 +74,13 @@ public abstract class IntegrationTestSupport {
 
         // --- Redis PubSub 설정 ---
         registry.add("messaging.redis.channels.chat-message", () -> "qootalk:chat:message");
+        registry.add("messaging.redis.channels.read-receipt", () -> "qootalk:chat:read-receipt");
         registry.add("messaging.redis.channels.user-presence", () -> "qootalk:user:presence");
         registry.add("messaging.redis.presence-ttl-seconds", () -> "300");
 
         // --- Kafka 설정 ---
         registry.add("messaging.kafka.topics.chat-message", () -> "qootalk.chat.message");
+        registry.add("messaging.kafka.topics.read-receipt", () -> "qootalk.read.receipt");
         registry.add("messaging.kafka.consumer-group", () -> "qootalk-chat");
     }
 }

--- a/qootalk-server/module-infrastructure/src/testFixtures/java/com/lrchan/qootalk/infrastructure/IntegrationTestSupport.java
+++ b/qootalk-server/module-infrastructure/src/testFixtures/java/com/lrchan/qootalk/infrastructure/IntegrationTestSupport.java
@@ -82,5 +82,7 @@ public abstract class IntegrationTestSupport {
         registry.add("messaging.kafka.topics.chat-message", () -> "qootalk.chat.message");
         registry.add("messaging.kafka.topics.read-receipt", () -> "qootalk.read.receipt");
         registry.add("messaging.kafka.consumer-group", () -> "qootalk-chat");
+        registry.add("messaging.kafka.partition-count", () -> "3");
+        registry.add("messaging.kafka.replication-factor", () -> "(short) 1");
     }
 }

--- a/qootalk-server/module-infrastructure/src/testFixtures/java/com/lrchan/qootalk/infrastructure/IntegrationTestSupport.java
+++ b/qootalk-server/module-infrastructure/src/testFixtures/java/com/lrchan/qootalk/infrastructure/IntegrationTestSupport.java
@@ -71,5 +71,14 @@ public abstract class IntegrationTestSupport {
         registry.add("jwt.secret", () -> "BZ8uxA8V9Iz//+hgMZ9j+TZBWNfytwMoJU3QkkcT/aQ=");
         registry.add("jwt.access-expiration", () -> "86400000");
         registry.add("jwt.refresh-expiration", () -> "604800000");
+
+        // --- Redis PubSub 설정 ---
+        registry.add("messaging.redis.channels.chat-message", () -> "qootalk:chat:message");
+        registry.add("messaging.redis.channels.user-presence", () -> "qootalk:user:presence");
+        registry.add("messaging.redis.presence-ttl-seconds", () -> "300");
+
+        // --- Kafka 설정 ---
+        registry.add("messaging.kafka.topics.chat-message", () -> "qootalk.chat.message");
+        registry.add("messaging.kafka.consumer-group", () -> "qootalk-chat");
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatHistoryController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatHistoryController.java
@@ -1,0 +1,75 @@
+package com.lrchan.qootalk.presentation.api.chat.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lrchan.qootalk.application.chat.dto.command.LoadChatHistoriesCommand;
+import com.lrchan.qootalk.application.chat.dto.result.ChatHistoryQueryResult;
+import com.lrchan.qootalk.application.chat.dto.result.ReadReceiptQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.LoadChatHistoriesUsecase;
+import com.lrchan.qootalk.application.chat.port.in.MarkMessageReadUsecase;
+import com.lrchan.qootalk.common.response.ApiResponse;
+import com.lrchan.qootalk.common.response.SliceResponse;
+import com.lrchan.qootalk.presentation.api.chat.dto.request.MarkMessageReadRequest;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.ChatHistoryResponse;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.ReadReceiptResponse;
+import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/chat-rooms/{roomId}")
+@RequiredArgsConstructor
+@Tag(name = "Chat History", description = "채팅 이력 API")
+public class ChatHistoryController {
+
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final LoadChatHistoriesUsecase loadChatHistoriesUsecase;
+    private final MarkMessageReadUsecase markMessageReadUsecase;
+
+    @GetMapping("/histories")
+    @Operation(
+        summary = "채팅 이력 조회",
+        description = "현재 로그인한 사용자가 참여 중인 채팅방의 메시지 이력을 Slice 형태로 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<SliceResponse<ChatHistoryResponse>>> getChatHistories(
+        @PathVariable Long roomId,
+        @RequestParam(required = false) Long fromMessageId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "50") int size
+    ) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        SliceResponse<ChatHistoryQueryResult> result = loadChatHistoriesUsecase.load(
+            new LoadChatHistoriesCommand(requesterId, roomId, fromMessageId, page, size)
+        );
+        SliceResponse<ChatHistoryResponse> response = SliceResponse.of(
+            result.content().stream().map(ChatHistoryResponse::of).toList(),
+            result.page(),
+            result.size(),
+            result.hasNext()
+        );
+        return ResponseEntity.ok(ApiResponse.of(response));
+    }
+
+    @PostMapping("/read")
+    @Operation(
+        summary = "메시지 읽음 처리",
+        description = "현재 로그인한 사용자의 마지막 읽은 메시지 위치를 갱신합니다."
+    )
+    public ResponseEntity<ApiResponse<ReadReceiptResponse>> markAsRead(
+        @PathVariable Long roomId,
+        @RequestBody MarkMessageReadRequest request
+    ) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        ReadReceiptQueryResult result = markMessageReadUsecase.mark(request.toCommand(requesterId, roomId));
+        return ResponseEntity.ok(ApiResponse.of(ReadReceiptResponse.of(result)));
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatStreamController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatStreamController.java
@@ -1,0 +1,58 @@
+package com.lrchan.qootalk.presentation.api.chat.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.lrchan.qootalk.infrastructure.messaging.presence.LocalUserConnectionRegistry;
+import com.lrchan.qootalk.infrastructure.messaging.presence.RedisUserPresenceTracker;
+import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/chat-stream")
+@RequiredArgsConstructor
+@Tag(name = "Chat Stream", description = "실시간 채팅 스트림 API")
+public class ChatStreamController {
+
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final LocalUserConnectionRegistry localUserConnectionRegistry;
+    private final RedisUserPresenceTracker redisUserPresenceTracker;
+
+    @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @Operation(
+        summary = "실시간 채팅 스트림 연결",
+        description = "현재 로그인한 사용자의 실시간 채팅 메시지 스트림을 구독합니다."
+    )
+    public ResponseEntity<SseEmitter> subscribe() throws Exception {
+        Long userId = authenticatedUserProvider.getCurrentUserId();
+        LocalUserConnectionRegistry.Connection connection = localUserConnectionRegistry.register(userId);
+        redisUserPresenceTracker.markConnected(userId, connection.connectionId());
+
+        connection.emitter().onCompletion(() -> {
+            localUserConnectionRegistry.remove(userId, connection.connectionId());
+            redisUserPresenceTracker.disconnect(userId, connection.connectionId());
+        });
+        connection.emitter().onTimeout(() -> {
+            localUserConnectionRegistry.remove(userId, connection.connectionId());
+            redisUserPresenceTracker.disconnect(userId, connection.connectionId());
+            connection.emitter().complete();
+        });
+        connection.emitter().onError(error -> {
+            localUserConnectionRegistry.remove(userId, connection.connectionId());
+            redisUserPresenceTracker.disconnect(userId, connection.connectionId());
+        });
+
+        connection.emitter().send(SseEmitter.event()
+            .name("connected")
+            .data("subscribed"));
+
+        return ResponseEntity.ok(connection.emitter());
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageController.java
@@ -1,6 +1,7 @@
 package com.lrchan.qootalk.presentation.api.chat.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -8,10 +9,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.lrchan.qootalk.application.chat.dto.result.SendMessageQueryResult;
+import com.lrchan.qootalk.application.chat.dto.result.UpdateMessageQueryResult;
 import com.lrchan.qootalk.application.chat.port.in.SendMessageUsecase;
+import com.lrchan.qootalk.application.chat.port.in.UpdateMessageUsecase;
 import com.lrchan.qootalk.common.response.ApiResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.request.SendMessageRequest;
+import com.lrchan.qootalk.presentation.api.chat.dto.request.UpdateMessageRequest;
 import com.lrchan.qootalk.presentation.api.chat.dto.response.SendMessageResponse;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.UpdateMessageResponse;
 import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,6 +31,7 @@ public class MessageController {
 
     private final AuthenticatedUserProvider authenticatedUserProvider;
     private final SendMessageUsecase sendMessageUsecase;
+    private final UpdateMessageUsecase updateMessageUsecase;
 
     @PostMapping
     @Operation(
@@ -39,5 +45,20 @@ public class MessageController {
         Long requesterId = authenticatedUserProvider.getCurrentUserId();
         SendMessageQueryResult result = sendMessageUsecase.send(request.toCommand(requesterId, roomId));
         return ResponseEntity.ok(ApiResponse.of(SendMessageResponse.of(result)));
+    }
+
+    @PatchMapping("/{messageId}")
+    @Operation(
+        summary = "메시지 수정",
+        description = "현재 로그인한 사용자가 본인이 작성한 메시지를 수정합니다."
+    )
+    public ResponseEntity<ApiResponse<UpdateMessageResponse>> updateMessage(
+        @PathVariable Long roomId,
+        @PathVariable Long messageId,
+        @RequestBody UpdateMessageRequest request
+    ) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        UpdateMessageQueryResult result = updateMessageUsecase.update(request.toCommand(requesterId, messageId));
+        return ResponseEntity.ok(ApiResponse.of(UpdateMessageResponse.of(result)));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageController.java
@@ -1,5 +1,6 @@
 package com.lrchan.qootalk.presentation.api.chat.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -8,10 +9,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.lrchan.qootalk.application.chat.dto.command.DeleteMessageCommand;
+import com.lrchan.qootalk.application.chat.dto.result.DeleteMessageQueryResult;
 import com.lrchan.qootalk.application.chat.dto.result.SendMessageQueryResult;
 import com.lrchan.qootalk.application.chat.dto.result.UpdateMessageQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.DeleteMessageUsecase;
 import com.lrchan.qootalk.application.chat.port.in.SendMessageUsecase;
 import com.lrchan.qootalk.application.chat.port.in.UpdateMessageUsecase;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.DeleteMessageResponse;
 import com.lrchan.qootalk.common.response.ApiResponse;
 import com.lrchan.qootalk.presentation.api.chat.dto.request.SendMessageRequest;
 import com.lrchan.qootalk.presentation.api.chat.dto.request.UpdateMessageRequest;
@@ -30,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 public class MessageController {
 
     private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final DeleteMessageUsecase deleteMessageUsecase;
     private final SendMessageUsecase sendMessageUsecase;
     private final UpdateMessageUsecase updateMessageUsecase;
 
@@ -60,5 +66,19 @@ public class MessageController {
         Long requesterId = authenticatedUserProvider.getCurrentUserId();
         UpdateMessageQueryResult result = updateMessageUsecase.update(request.toCommand(requesterId, messageId));
         return ResponseEntity.ok(ApiResponse.of(UpdateMessageResponse.of(result)));
+    }
+
+    @DeleteMapping("/{messageId}")
+    @Operation(
+        summary = "메시지 삭제",
+        description = "현재 로그인한 사용자가 본인이 작성한 메시지를 삭제합니다."
+    )
+    public ResponseEntity<ApiResponse<DeleteMessageResponse>> deleteMessage(
+        @PathVariable Long roomId,
+        @PathVariable Long messageId
+    ) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        DeleteMessageQueryResult result = deleteMessageUsecase.delete(new DeleteMessageCommand(requesterId, messageId));
+        return ResponseEntity.ok(ApiResponse.of(DeleteMessageResponse.of(result)));
     }
 }

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageController.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageController.java
@@ -1,0 +1,43 @@
+package com.lrchan.qootalk.presentation.api.chat.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lrchan.qootalk.application.chat.dto.result.SendMessageQueryResult;
+import com.lrchan.qootalk.application.chat.port.in.SendMessageUsecase;
+import com.lrchan.qootalk.common.response.ApiResponse;
+import com.lrchan.qootalk.presentation.api.chat.dto.request.SendMessageRequest;
+import com.lrchan.qootalk.presentation.api.chat.dto.response.SendMessageResponse;
+import com.lrchan.qootalk.presentation.global.auth.AuthenticatedUserProvider;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/chat-rooms/{roomId}/messages")
+@RequiredArgsConstructor
+@Tag(name = "Message", description = "메시지 API")
+public class MessageController {
+
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final SendMessageUsecase sendMessageUsecase;
+
+    @PostMapping
+    @Operation(
+        summary = "메시지 전송",
+        description = "현재 로그인한 사용자가 채팅방에 메시지를 전송합니다."
+    )
+    public ResponseEntity<ApiResponse<SendMessageResponse>> sendMessage(
+        @PathVariable Long roomId,
+        @RequestBody SendMessageRequest request
+    ) {
+        Long requesterId = authenticatedUserProvider.getCurrentUserId();
+        SendMessageQueryResult result = sendMessageUsecase.send(request.toCommand(requesterId, roomId));
+        return ResponseEntity.ok(ApiResponse.of(SendMessageResponse.of(result)));
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/request/MarkMessageReadRequest.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/request/MarkMessageReadRequest.java
@@ -1,0 +1,15 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.request;
+
+import com.lrchan.qootalk.application.chat.dto.command.MarkMessageReadCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메시지 읽음 처리 요청")
+public record MarkMessageReadRequest(
+    @Schema(description = "마지막으로 읽은 메시지 ID", example = "1001")
+    Long lastReadMessageId
+) {
+    public MarkMessageReadCommand toCommand(Long requesterId, Long roomId) {
+        return new MarkMessageReadCommand(requesterId, roomId, lastReadMessageId);
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/request/SendMessageRequest.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/request/SendMessageRequest.java
@@ -1,0 +1,34 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.request;
+
+import java.util.List;
+
+import com.lrchan.qootalk.application.chat.dto.command.SendMessageCommand;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메시지 전송 요청")
+public record SendMessageRequest(
+    @Schema(description = "메시지 내용", example = "안녕하세요")
+    String content,
+    @Schema(description = "메시지 타입", example = "TEXT")
+    MessageType messageType,
+    @Schema(description = "멘션 사용자 ID 목록", example = "[12, 15]")
+    List<Long> mentions,
+    @Schema(description = "부모 메시지 ID", example = "1000")
+    Long parentMessageId,
+    @Schema(description = "첨부 파일 ID 목록", example = "[101, 102]")
+    List<Long> attachmentIds
+) {
+    public SendMessageCommand toCommand(Long requesterId, Long roomId) {
+        return new SendMessageCommand(
+            requesterId,
+            roomId,
+            content,
+            messageType,
+            mentions,
+            parentMessageId,
+            attachmentIds
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/request/UpdateMessageRequest.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/request/UpdateMessageRequest.java
@@ -1,0 +1,15 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.request;
+
+import com.lrchan.qootalk.application.chat.dto.command.UpdateMessageCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메시지 수정 요청")
+public record UpdateMessageRequest(
+    @Schema(description = "수정할 메시지 내용", example = "안녕하세요. 수정본입니다.")
+    String content
+) {
+    public UpdateMessageCommand toCommand(Long requesterId, Long messageId) {
+        return new UpdateMessageCommand(requesterId, messageId, content);
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/ChatHistoryResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/ChatHistoryResponse.java
@@ -1,0 +1,35 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.chat.dto.result.ChatHistoryQueryResult;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅 이력 응답")
+public record ChatHistoryResponse(
+    @Schema(description = "메시지 ID", example = "1001")
+    Long id,
+    @Schema(description = "채팅방 ID", example = "10")
+    Long roomId,
+    @Schema(description = "발신자 ID", example = "1")
+    Long senderId,
+    @Schema(description = "메시지 내용", example = "안녕하세요")
+    String content,
+    @Schema(description = "메시지 타입", example = "TEXT")
+    MessageType messageType,
+    @Schema(description = "전송 시각", example = "2026-03-12T11:20:00")
+    LocalDateTime createdAt
+) {
+    public static ChatHistoryResponse of(ChatHistoryQueryResult result) {
+        return new ChatHistoryResponse(
+            result.id(),
+            result.roomId(),
+            result.senderId(),
+            result.content(),
+            result.messageType(),
+            result.createdAt()
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/DeleteMessageResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/DeleteMessageResponse.java
@@ -1,0 +1,17 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import com.lrchan.qootalk.application.chat.dto.result.DeleteMessageQueryResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메시지 삭제 응답")
+public record DeleteMessageResponse(
+    @Schema(description = "삭제 여부", example = "true")
+    boolean deleted,
+    @Schema(description = "메시지 ID", example = "1001")
+    Long messageId
+) {
+    public static DeleteMessageResponse of(DeleteMessageQueryResult result) {
+        return new DeleteMessageResponse(result.deleted(), result.messageId());
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/ReadReceiptResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/ReadReceiptResponse.java
@@ -1,0 +1,23 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import com.lrchan.qootalk.application.chat.dto.result.ReadReceiptQueryResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메시지 읽음 처리 응답")
+public record ReadReceiptResponse(
+    @Schema(description = "채팅방 ID", example = "10")
+    Long roomId,
+    @Schema(description = "마지막 읽은 메시지 ID", example = "1001")
+    Long lastReadMessageId,
+    @Schema(description = "읽음 상태 갱신 여부", example = "true")
+    boolean updated
+) {
+    public static ReadReceiptResponse of(ReadReceiptQueryResult result) {
+        return new ReadReceiptResponse(
+            result.roomId(),
+            result.lastReadMessageId(),
+            result.updated()
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/SendMessageResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/SendMessageResponse.java
@@ -1,0 +1,45 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.lrchan.qootalk.application.chat.dto.result.SendMessageQueryResult;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메시지 전송 응답")
+public record SendMessageResponse(
+    @Schema(description = "메시지 ID", example = "1001")
+    Long id,
+    @Schema(description = "채팅방 ID", example = "10")
+    Long roomId,
+    @Schema(description = "발신자 ID", example = "1")
+    Long senderId,
+    @Schema(description = "메시지 내용", example = "안녕하세요")
+    String content,
+    @Schema(description = "메시지 타입", example = "TEXT")
+    MessageType messageType,
+    @Schema(description = "멘션 사용자 ID 목록", example = "[12, 15]")
+    List<Long> mentions,
+    @Schema(description = "부모 메시지 ID", example = "1000")
+    Long parentMessageId,
+    @Schema(description = "첨부 파일 ID 목록", example = "[101, 102]")
+    List<Long> attachmentIds,
+    @Schema(description = "생성 시각", example = "2026-03-12T11:20:00")
+    LocalDateTime createdAt
+) {
+    public static SendMessageResponse of(SendMessageQueryResult result) {
+        return new SendMessageResponse(
+            result.id(),
+            result.roomId(),
+            result.senderId(),
+            result.content(),
+            result.messageType(),
+            result.mentions(),
+            result.parentMessageId(),
+            result.attachmentIds(),
+            result.createdAt()
+        );
+    }
+}

--- a/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/UpdateMessageResponse.java
+++ b/qootalk-server/module-presentation/src/main/java/com/lrchan/qootalk/presentation/api/chat/dto/response/UpdateMessageResponse.java
@@ -1,0 +1,21 @@
+package com.lrchan.qootalk.presentation.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.lrchan.qootalk.application.chat.dto.result.UpdateMessageQueryResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메시지 수정 응답")
+public record UpdateMessageResponse(
+    @Schema(description = "메시지 ID", example = "1001")
+    Long messageId,
+    @Schema(description = "수정된 내용", example = "안녕하세요. 수정본입니다.")
+    String content,
+    @Schema(description = "수정 시각", example = "2026-03-12T11:21:00")
+    LocalDateTime updatedAt
+) {
+    public static UpdateMessageResponse of(UpdateMessageQueryResult result) {
+        return new UpdateMessageResponse(result.messageId(), result.content(), result.updatedAt());
+    }
+}

--- a/qootalk-server/module-presentation/src/main/resources/application-local.yml
+++ b/qootalk-server/module-presentation/src/main/resources/application-local.yml
@@ -50,10 +50,12 @@ messaging:
   kafka:
     topics:
       chat-message: ${CHAT_MESSAGE_TOPIC:qootalk.chat.message}
+      read-receipt: ${READ_RECEIPT_TOPIC:qootalk.read.receipt}
     consumer-group: ${LOCAL_KAFKA_CONSUMER_GROUP:qootalk-chat-local}
   redis:
     channels:
       chat-message: ${REDIS_CHAT_MESSAGE_CHANNEL:qootalk:chat:message}
+      read-receipt: ${REDIS_READ_RECEIPT_CHANNEL:qootalk:chat:read-receipt}
       user-presence: ${REDIS_USER_PRESENCE_CHANNEL:qootalk:user:presence}
     presence-ttl-seconds: ${REDIS_PRESENCE_TTL_SECONDS:300}
 

--- a/qootalk-server/module-presentation/src/main/resources/application-local.yml
+++ b/qootalk-server/module-presentation/src/main/resources/application-local.yml
@@ -52,6 +52,8 @@ messaging:
       chat-message: ${CHAT_MESSAGE_TOPIC:qootalk.chat.message}
       read-receipt: ${READ_RECEIPT_TOPIC:qootalk.read.receipt}
     consumer-group: ${LOCAL_KAFKA_CONSUMER_GROUP:qootalk-chat-local}
+    partition-count: ${LOCAL_KAFKA_PARTITION_COUNT:3}
+    replication-factor: ${LOCAL_KAFKA_REPLICATION_FACTOR:(short) 1}
   redis:
     channels:
       chat-message: ${REDIS_CHAT_MESSAGE_CHANNEL:qootalk:chat:message}

--- a/qootalk-server/module-presentation/src/main/resources/application-local.yml
+++ b/qootalk-server/module-presentation/src/main/resources/application-local.yml
@@ -27,6 +27,30 @@ spring:
       host: ${LOCAL_REDIS_HOST}
       port: ${LOCAL_REDIS_PORT}
 
+  kafka:
+    bootstrap-servers: ${LOCAL_KAFKA_BOOTSTRAP_SERVERS:localhost:9094}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: ${LOCAL_KAFKA_CONSUMER_GROUP:qootalk-chat-local}
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: earliest
+      properties:
+        spring.json.trusted.packages: "*"
+
+messaging:
+  kafka:
+    topics:
+      chat-message: ${CHAT_MESSAGE_TOPIC:qootalk.chat.message}
+    consumer-group: ${LOCAL_KAFKA_CONSUMER_GROUP:qootalk-chat-local}
+  redis:
+    channels:
+      chat-message: ${REDIS_CHAT_MESSAGE_CHANNEL:qootalk:chat:message}
+      user-presence: ${REDIS_USER_PRESENCE_CHANNEL:qootalk:user:presence}
+    presence-ttl-seconds: ${REDIS_PRESENCE_TTL_SECONDS:300}
+
 aws:
   s3:
     endpoint: ${LOCAL_S3_ENDPOINT}

--- a/qootalk-server/module-presentation/src/main/resources/application-local.yml
+++ b/qootalk-server/module-presentation/src/main/resources/application-local.yml
@@ -1,3 +1,9 @@
+qootalk:
+  channels:
+    chat-message: qootalk:chat:message
+    user-presence: qootalk:user:presence
+  presence-ttl-seconds: 300
+
 spring:
   config:
     import: "optional:file:.env[.properties],optional:file:../.env[.properties]"

--- a/qootalk-server/module-presentation/src/main/resources/application-prod.yml
+++ b/qootalk-server/module-presentation/src/main/resources/application-prod.yml
@@ -41,10 +41,12 @@ messaging:
   kafka:
     topics:
       chat-message: ${CHAT_MESSAGE_TOPIC:qootalk.chat.message}
+      read-receipt: ${READ_RECEIPT_TOPIC:qootalk.read.receipt}
     consumer-group: ${PROD_KAFKA_CONSUMER_GROUP:qootalk-chat-prod}
   redis:
     channels:
       chat-message: ${REDIS_CHAT_MESSAGE_CHANNEL:qootalk:chat:message}
+      read-receipt: ${REDIS_READ_RECEIPT_CHANNEL:qootalk:chat:read-receipt}
       user-presence: ${REDIS_USER_PRESENCE_CHANNEL:qootalk:user:presence}
     presence-ttl-seconds: ${REDIS_PRESENCE_TTL_SECONDS:300}
 

--- a/qootalk-server/module-presentation/src/main/resources/application-prod.yml
+++ b/qootalk-server/module-presentation/src/main/resources/application-prod.yml
@@ -19,4 +19,33 @@ spring:
     baseline-on-migrate: true
     clean-disabled: true
 
+  data:
+    redis:
+      host: ${PROD_REDIS_HOST}
+      port: ${PROD_REDIS_PORT}
+
+  kafka:
+    bootstrap-servers: ${PROD_KAFKA_BOOTSTRAP_SERVERS}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: ${PROD_KAFKA_CONSUMER_GROUP:qootalk-chat-prod}
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: earliest
+      properties:
+        spring.json.trusted.packages: "*"
+
+messaging:
+  kafka:
+    topics:
+      chat-message: ${CHAT_MESSAGE_TOPIC:qootalk.chat.message}
+    consumer-group: ${PROD_KAFKA_CONSUMER_GROUP:qootalk-chat-prod}
+  redis:
+    channels:
+      chat-message: ${REDIS_CHAT_MESSAGE_CHANNEL:qootalk:chat:message}
+      user-presence: ${REDIS_USER_PRESENCE_CHANNEL:qootalk:user:presence}
+    presence-ttl-seconds: ${REDIS_PRESENCE_TTL_SECONDS:300}
+
 # 추후 aws s3 설정 추가

--- a/qootalk-server/module-presentation/src/test/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatHistoryControllerIntegrationTest.java
+++ b/qootalk-server/module-presentation/src/test/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatHistoryControllerIntegrationTest.java
@@ -1,0 +1,154 @@
+package com.lrchan.qootalk.presentation.api.chat.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+import com.lrchan.qootalk.infrastructure.persistence.user.UserEntity;
+import com.lrchan.qootalk.presentation.support.ApiIntegrationTestSupport;
+
+class ChatHistoryControllerIntegrationTest extends ApiIntegrationTestSupport {
+
+    @Nested
+    @DisplayName("채팅 이력 조회")
+    class LoadHistoriesTest {
+        @Test
+        @DisplayName("채팅 이력은 Slice 형태로 조회된다")
+        void getChatHistoriesSuccess() throws Exception {
+            UserEntity sender = createUser("history-sender@qootalk.com", "Password123!", "기록발신자");
+            UserEntity member = createUser("history-member@qootalk.com", "Password123!", "기록멤버");
+
+            Long roomId = createChatRoom(sender, member.getId());
+            sendMessage(sender, roomId, "첫 번째 메시지");
+            sendMessage(sender, roomId, "두 번째 메시지");
+
+            mockMvc.perform(authorized(get(CHAT_ROOM_API_PREFIX + "/" + roomId + "/histories"), sender)
+                    .param("page", "0")
+                    .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content", hasSize(2)))
+                .andExpect(jsonPath("$.data.content[0].content").value("두 번째 메시지"))
+                .andExpect(jsonPath("$.data.hasNext").value(true));
+        }
+
+        @Test
+        @DisplayName("참여하지 않은 사용자는 채팅 이력을 조회할 수 없다")
+        void getChatHistoriesFailsWhenNotParticipant() throws Exception {
+            UserEntity owner = createUser("history-owner@qootalk.com", "Password123!", "기록방장");
+            UserEntity member = createUser("history-room-member@qootalk.com", "Password123!", "기록참여자");
+            UserEntity outsider = createUser("history-outsider@qootalk.com", "Password123!", "기록외부인");
+
+            Long roomId = createChatRoom(owner, member.getId());
+
+            mockMvc.perform(authorized(get(CHAT_ROOM_API_PREFIX + "/" + roomId + "/histories"), outsider)
+                    .param("page", "0")
+                    .param("size", "20"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("CHAT_007"));
+        }
+    }
+
+    @Nested
+    @DisplayName("읽음 처리")
+    class MarkReadTest {
+        @Test
+        @DisplayName("더 최신 메시지로 읽음 처리를 할 수 있다")
+        void markAsReadSuccess() throws Exception {
+            UserEntity sender = createUser("read-sender@qootalk.com", "Password123!", "읽음발신자");
+            UserEntity member = createUser("read-member@qootalk.com", "Password123!", "읽음멤버");
+
+            Long roomId = createChatRoom(sender, member.getId());
+            Long messageId = sendMessage(sender, roomId, "읽음 대상 메시지");
+
+            mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX + "/" + roomId + "/read"), member)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json(new MarkMessageReadRequest(messageId))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.roomId").value(roomId))
+                .andExpect(jsonPath("$.data.lastReadMessageId").value(messageId))
+                .andExpect(jsonPath("$.data.updated").value(true));
+        }
+
+        @Test
+        @DisplayName("이미 읽은 메시지를 다시 읽음 처리하면 updated=false를 반환한다")
+        void markAsReadReturnsFalseWhenAlreadyRead() throws Exception {
+            UserEntity sender = createUser("read2-sender@qootalk.com", "Password123!", "읽음2발신자");
+            UserEntity member = createUser("read2-member@qootalk.com", "Password123!", "읽음2멤버");
+
+            Long roomId = createChatRoom(sender, member.getId());
+            Long messageId = sendMessage(sender, roomId, "이미 읽은 메시지");
+
+            mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX + "/" + roomId + "/read"), member)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json(new MarkMessageReadRequest(messageId))))
+                .andExpect(status().isOk());
+
+            mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX + "/" + roomId + "/read"), member)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json(new MarkMessageReadRequest(messageId))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.updated").value(false));
+        }
+    }
+
+    private Long createChatRoom(UserEntity requester, Long... participantIds) throws Exception {
+        MvcResult result = mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX), requester)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json(new CreateChatRoomRequest(
+                    "이력방",
+                    RoomType.GROUP,
+                    participantIds,
+                    true
+                ))))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode json = objectMapper.readTree(responseBody(result));
+        return json.path("data").path("id").asLong();
+    }
+
+    private Long sendMessage(UserEntity sender, Long roomId, String content) throws Exception {
+        MvcResult result = mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages"), sender)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json(new SendMessageRequest(content, MessageType.TEXT, new Long[] {}, null, new Long[] {}))))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode json = objectMapper.readTree(responseBody(result));
+        return json.path("data").path("id").asLong();
+    }
+
+    private record CreateChatRoomRequest(
+        String roomName,
+        RoomType roomType,
+        Long[] participantIds,
+        boolean notificationEnabled
+    ) {
+    }
+
+    private record SendMessageRequest(
+        String content,
+        MessageType messageType,
+        Long[] mentions,
+        Long parentMessageId,
+        Long[] attachmentIds
+    ) {
+    }
+
+    private record MarkMessageReadRequest(Long lastReadMessageId) {
+    }
+}

--- a/qootalk-server/module-presentation/src/test/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatHistoryControllerIntegrationTest.java
+++ b/qootalk-server/module-presentation/src/test/java/com/lrchan/qootalk/presentation/api/chat/controller/ChatHistoryControllerIntegrationTest.java
@@ -44,6 +44,41 @@ class ChatHistoryControllerIntegrationTest extends ApiIntegrationTestSupport {
         }
 
         @Test
+        @DisplayName("대량 메시지도 fromMessageId 기반으로 안정적으로 페이징 조회할 수 있다")
+        void getChatHistoriesWithFromMessageIdPaging() throws Exception {
+            UserEntity sender = createUser("history-paging-sender@qootalk.com", "Password123!", "기록페이징발신자");
+            UserEntity member = createUser("history-paging-member@qootalk.com", "Password123!", "기록페이징멤버");
+
+            Long roomId = createChatRoom(sender, member.getId());
+
+            Long lastMessageId = null;
+            for (int i = 1; i <= 25; i++) {
+                lastMessageId = sendMessage(sender, roomId, "message-" + i);
+            }
+
+            MvcResult firstPageResult = mockMvc.perform(authorized(get(CHAT_ROOM_API_PREFIX + "/" + roomId + "/histories"), sender)
+                    .param("page", "0")
+                    .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content", hasSize(10)))
+                .andExpect(jsonPath("$.data.content[0].content").value("message-25"))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andReturn();
+
+            JsonNode firstPageJson = objectMapper.readTree(responseBody(firstPageResult));
+            long fromMessageId = firstPageJson.path("data").path("content").get(9).path("id").asLong();
+
+            mockMvc.perform(authorized(get(CHAT_ROOM_API_PREFIX + "/" + roomId + "/histories"), sender)
+                    .param("fromMessageId", String.valueOf(fromMessageId))
+                    .param("page", "0")
+                    .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content", hasSize(10)))
+                .andExpect(jsonPath("$.data.content[0].content").value("message-15"))
+                .andExpect(jsonPath("$.data.hasNext").value(true));
+        }
+
+        @Test
         @DisplayName("참여하지 않은 사용자는 채팅 이력을 조회할 수 없다")
         void getChatHistoriesFailsWhenNotParticipant() throws Exception {
             UserEntity owner = createUser("history-owner@qootalk.com", "Password123!", "기록방장");

--- a/qootalk-server/module-presentation/src/test/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageControllerIntegrationTest.java
+++ b/qootalk-server/module-presentation/src/test/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageControllerIntegrationTest.java
@@ -1,0 +1,189 @@
+package com.lrchan.qootalk.presentation.api.chat.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+import com.lrchan.qootalk.infrastructure.persistence.user.UserEntity;
+import com.lrchan.qootalk.presentation.support.ApiIntegrationTestSupport;
+
+class MessageControllerIntegrationTest extends ApiIntegrationTestSupport {
+
+    @Nested
+    @DisplayName("메시지 전송")
+    class SendMessageTest {
+        @Test
+        @DisplayName("참여 사용자는 텍스트 메시지를 전송할 수 있다")
+        void sendTextMessageSuccess() throws Exception {
+            UserEntity sender = createUser("sender@qootalk.com", "Password123!", "발신자");
+            UserEntity member = createUser("receiver@qootalk.com", "Password123!", "수신자");
+
+            Long roomId = createChatRoom(sender, member.getId());
+
+            MvcResult result = mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages"), sender)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json(new SendMessageRequest(
+                        "안녕하세요",
+                        MessageType.TEXT,
+                        new Long[] {member.getId()},
+                        null,
+                        new Long[] {}
+                    ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.roomId").value(roomId))
+                .andExpect(jsonPath("$.data.senderId").value(sender.getId()))
+                .andExpect(jsonPath("$.data.content").value("안녕하세요"))
+                .andExpect(jsonPath("$.data.messageType").value(MessageType.TEXT.name()))
+                .andReturn();
+
+            JsonNode json = objectMapper.readTree(responseBody(result));
+            Long messageId = json.path("data").path("id").asLong();
+
+            org.assertj.core.api.Assertions.assertThat(messageJpaRepository.count()).isEqualTo(2L);
+            org.assertj.core.api.Assertions.assertThat(lastReadMessageId(sender.getId(), roomId)).isEqualTo(messageId);
+        }
+
+        @Test
+        @DisplayName("업로드한 첨부파일을 포함한 파일 메시지를 전송할 수 있다")
+        void sendFileMessageSuccess() throws Exception {
+            UserEntity sender = createUser("file-sender@qootalk.com", "Password123!", "파일발신자");
+            UserEntity member = createUser("file-member@qootalk.com", "Password123!", "파일수신자");
+
+            Long roomId = createChatRoom(sender, member.getId());
+            long uploadedFileId = uploadFile(
+                sender,
+                roomId,
+                lastReadMessageId(sender.getId(), roomId),
+                "message-file.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "message-file"
+            );
+
+            mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages"), sender)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json(new SendMessageRequest(
+                        null,
+                        MessageType.FILE,
+                        new Long[] {},
+                        null,
+                        new Long[] {uploadedFileId}
+                    ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.messageType").value(MessageType.FILE.name()))
+                .andExpect(jsonPath("$.data.attachmentIds[0]").value(uploadedFileId));
+        }
+
+        @Test
+        @DisplayName("참여하지 않은 사용자는 메시지를 전송할 수 없다")
+        void sendMessageFailsWhenNotParticipant() throws Exception {
+            UserEntity owner = createUser("owner-message@qootalk.com", "Password123!", "메시지방장");
+            UserEntity member = createUser("member-message@qootalk.com", "Password123!", "메시지멤버");
+            UserEntity outsider = createUser("outsider-message@qootalk.com", "Password123!", "외부인");
+
+            Long roomId = createChatRoom(owner, member.getId());
+
+            mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages"), outsider)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json(new SendMessageRequest(
+                        "전송 실패",
+                        MessageType.TEXT,
+                        new Long[] {},
+                        null,
+                        new Long[] {}
+                    ))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("CHAT_007"))
+                .andExpect(jsonPath("$.error.message").value("채팅방 참여자를 찾을 수 없습니다."));
+        }
+
+        @Test
+        @DisplayName("내용과 첨부파일이 모두 없으면 메시지 전송에 실패한다")
+        void sendMessageFailsWhenPayloadEmpty() throws Exception {
+            UserEntity sender = createUser("empty-sender@qootalk.com", "Password123!", "빈메시지발신자");
+            UserEntity member = createUser("empty-member@qootalk.com", "Password123!", "빈메시지수신자");
+
+            Long roomId = createChatRoom(sender, member.getId());
+
+            mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages"), sender)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json(new SendMessageRequest(
+                        "   ",
+                        MessageType.TEXT,
+                        new Long[] {},
+                        null,
+                        new Long[] {}
+                    ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("CHAT_021"))
+                .andExpect(jsonPath("$.error.message").value("메시지 내용 또는 첨부파일이 필요합니다."));
+        }
+    }
+
+    private Long createChatRoom(UserEntity requester, Long... participantIds) throws Exception {
+        MvcResult result = mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX), requester)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json(new CreateChatRoomRequest(
+                    "메시지방",
+                    RoomType.GROUP,
+                    participantIds,
+                    true
+                ))))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode json = objectMapper.readTree(responseBody(result));
+        return json.path("data").path("id").asLong();
+    }
+
+    private long uploadFile(
+        UserEntity uploader,
+        Long roomId,
+        Long messageId,
+        String fileName,
+        String contentType,
+        String content
+    ) throws Exception {
+        MvcResult uploadResult = mockMvc.perform(authorized(
+                    multipart(FILE_API_PREFIX)
+                        .file(multipartFile("file", fileName, contentType, content))
+                        .param("roomId", String.valueOf(roomId))
+                        .param("messageId", String.valueOf(messageId)),
+                    uploader))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode uploadJson = objectMapper.readTree(responseBody(uploadResult));
+        return uploadJson.path("data").path("id").asLong();
+    }
+
+    private record CreateChatRoomRequest(
+        String roomName,
+        RoomType roomType,
+        Long[] participantIds,
+        boolean notificationEnabled
+    ) {
+    }
+
+    private record SendMessageRequest(
+        String content,
+        MessageType messageType,
+        Long[] mentions,
+        Long parentMessageId,
+        Long[] attachmentIds
+    ) {
+    }
+}

--- a/qootalk-server/module-presentation/src/test/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageDeleteControllerIntegrationTest.java
+++ b/qootalk-server/module-presentation/src/test/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageDeleteControllerIntegrationTest.java
@@ -1,0 +1,95 @@
+package com.lrchan.qootalk.presentation.api.chat.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+import com.lrchan.qootalk.infrastructure.persistence.user.UserEntity;
+import com.lrchan.qootalk.presentation.support.ApiIntegrationTestSupport;
+
+class MessageDeleteControllerIntegrationTest extends ApiIntegrationTestSupport {
+
+    @Nested
+    @DisplayName("메시지 삭제")
+    class DeleteMessageTest {
+        @Test
+        @DisplayName("작성자는 메시지를 삭제할 수 있다")
+        void deleteMessageSuccess() throws Exception {
+            UserEntity sender = createUser("delete-sender@qootalk.com", "Password123!", "삭제발신자");
+            UserEntity member = createUser("delete-member@qootalk.com", "Password123!", "삭제멤버");
+
+            Long roomId = createChatRoom(sender, member.getId());
+            Long messageId = sendMessage(sender, roomId, "삭제할 메시지");
+
+            mockMvc.perform(authorized(delete(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages/" + messageId), sender))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.deleted").value(true))
+                .andExpect(jsonPath("$.data.messageId").value(messageId));
+        }
+
+        @Test
+        @DisplayName("작성자가 아닌 사용자는 메시지를 삭제할 수 없다")
+        void deleteMessageFailsWhenRequesterIsNotAuthor() throws Exception {
+            UserEntity sender = createUser("delete2-sender@qootalk.com", "Password123!", "삭제2발신자");
+            UserEntity member = createUser("delete2-member@qootalk.com", "Password123!", "삭제2멤버");
+
+            Long roomId = createChatRoom(sender, member.getId());
+            Long messageId = sendMessage(sender, roomId, "삭제할 메시지");
+
+            mockMvc.perform(authorized(delete(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages/" + messageId), member))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("CHAT_032"));
+        }
+    }
+
+    private Long createChatRoom(UserEntity requester, Long... participantIds) throws Exception {
+        MvcResult result = mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX), requester)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json(new CreateChatRoomRequest("삭제방", RoomType.GROUP, participantIds, true))))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode json = objectMapper.readTree(responseBody(result));
+        return json.path("data").path("id").asLong();
+    }
+
+    private Long sendMessage(UserEntity sender, Long roomId, String content) throws Exception {
+        MvcResult result = mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages"), sender)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json(new SendMessageRequest(content, MessageType.TEXT, new Long[] {}, null, new Long[] {}))))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode json = objectMapper.readTree(responseBody(result));
+        return json.path("data").path("id").asLong();
+    }
+
+    private record CreateChatRoomRequest(
+        String roomName,
+        RoomType roomType,
+        Long[] participantIds,
+        boolean notificationEnabled
+    ) {
+    }
+
+    private record SendMessageRequest(
+        String content,
+        MessageType messageType,
+        Long[] mentions,
+        Long parentMessageId,
+        Long[] attachmentIds
+    ) {
+    }
+}

--- a/qootalk-server/module-presentation/src/test/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageUpdateControllerIntegrationTest.java
+++ b/qootalk-server/module-presentation/src/test/java/com/lrchan/qootalk/presentation/api/chat/controller/MessageUpdateControllerIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.lrchan.qootalk.presentation.api.chat.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.lrchan.qootalk.domain.chat.message.MessageType;
+import com.lrchan.qootalk.domain.chat.room.RoomType;
+import com.lrchan.qootalk.infrastructure.persistence.user.UserEntity;
+import com.lrchan.qootalk.presentation.support.ApiIntegrationTestSupport;
+
+class MessageUpdateControllerIntegrationTest extends ApiIntegrationTestSupport {
+
+    @Nested
+    @DisplayName("메시지 수정")
+    class UpdateMessageTest {
+        @Test
+        @DisplayName("작성자는 메시지를 수정할 수 있다")
+        void updateMessageSuccess() throws Exception {
+            UserEntity sender = createUser("edit-sender@qootalk.com", "Password123!", "수정발신자");
+            UserEntity member = createUser("edit-member@qootalk.com", "Password123!", "수정멤버");
+
+            Long roomId = createChatRoom(sender, member.getId());
+            Long messageId = sendMessage(sender, roomId, "원본 메시지");
+
+            mockMvc.perform(authorized(patch(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages/" + messageId), sender)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json(new UpdateMessageRequest("수정된 메시지"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.messageId").value(messageId))
+                .andExpect(jsonPath("$.data.content").value("수정된 메시지"))
+                .andExpect(jsonPath("$.data.updatedAt").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("작성자가 아닌 사용자는 메시지를 수정할 수 없다")
+        void updateMessageFailsWhenRequesterIsNotAuthor() throws Exception {
+            UserEntity sender = createUser("edit2-sender@qootalk.com", "Password123!", "수정2발신자");
+            UserEntity member = createUser("edit2-member@qootalk.com", "Password123!", "수정2멤버");
+
+            Long roomId = createChatRoom(sender, member.getId());
+            Long messageId = sendMessage(sender, roomId, "원본 메시지");
+
+            mockMvc.perform(authorized(patch(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages/" + messageId), member)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json(new UpdateMessageRequest("수정 시도"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("CHAT_030"));
+        }
+    }
+
+    private Long createChatRoom(UserEntity requester, Long... participantIds) throws Exception {
+        MvcResult result = mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX), requester)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json(new CreateChatRoomRequest("수정방", RoomType.GROUP, participantIds, true))))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode json = objectMapper.readTree(responseBody(result));
+        return json.path("data").path("id").asLong();
+    }
+
+    private Long sendMessage(UserEntity sender, Long roomId, String content) throws Exception {
+        MvcResult result = mockMvc.perform(authorized(post(CHAT_ROOM_API_PREFIX + "/" + roomId + "/messages"), sender)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json(new SendMessageRequest(content, MessageType.TEXT, new Long[] {}, null, new Long[] {}))))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode json = objectMapper.readTree(responseBody(result));
+        return json.path("data").path("id").asLong();
+    }
+
+    private record CreateChatRoomRequest(
+        String roomName,
+        RoomType roomType,
+        Long[] participantIds,
+        boolean notificationEnabled
+    ) {
+    }
+
+    private record SendMessageRequest(
+        String content,
+        MessageType messageType,
+        Long[] mentions,
+        Long parentMessageId,
+        Long[] attachmentIds
+    ) {
+    }
+
+    private record UpdateMessageRequest(String content) {
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #87 
## 📝작업 내용
- 메시징 인프라 구성
  - Kafka, Redis 기반 메시징 인프라 설정 추가
    - kafka 파티션 3개로 설정
  - 로컬 개발 환경용 Kafka/Redis 실행 환경 구성
  - Kafka 토픽, Redis Pub/Sub 채널, presence 설정 추가
  - 테스트 환경에서 Kafka/Redis 연동 가능하도록 Testcontainers 설정 추가

- 실시간 메시지 브로드캐스팅
  - 메시지 저장 후 Kafka 이벤트 발행
  - Kafka Consumer에서 현재 접속 중인 사용자만 식별하여 Redis Pub/Sub로 라우팅
  - SSE 기반 실시간 채팅 스트림 구독 API 추가
  - Redis presence 기반 접속 사용자 식별 처리 추가

---

- 메시지 전송 및 저장
  - 채팅방 참여자가 메시지를 전송할 수 있는 서비스 구현
  - 메시지 타입에 따른 처리 로직 추가
  - 메시지 전송 시 `MessageEntity` 저장 및 발신 시간 기록
  - 발신자의 마지막 읽음 위치 갱신 처리 추가

- 채팅 이력 조회 및 읽음 처리
  - 특정 채팅방 메시지 이력을 `Slice` 기반으로 페이징 조회
  - `fromMessageId` 기반 이력 조회 지원
  - Read Receipt 갱신 기능 추가
  - 읽음 상태 갱신 시 실시간 브로드캐스트 이벤트 발행 추가

- 메시지 수정/삭제 기능
  - 메시지 수정 API 추가
  - 작성자만 수정 가능하도록 권한 검증
  - 빈 내용 수정 및 일부 메시지 타입 수정 제한
  - 메시지 삭제 API 추가
  - 작성자 기준 삭제 처리 로직 추가

---

- 테스트 추가
  - 메시지 전송 성공/실패 서비스 테스트 추가
  - 메시지 전송 API 통합 테스트 추가
  - 채팅 이력 조회/읽음 처리 통합 테스트 추가
  - 메시지 수정/삭제 서비스 및 API 테스트 추가
  - 대량 메시지 조회 시 Slice 페이징 테스트 추가
  - 저장소 레벨 메시지 슬라이스 조회 테스트 추가
  - 읽음 상태 브로드캐스트 테스트 추가


## 기타

- 추후 메세징 성능 개선 에정
